### PR TITLE
refactor[next]: normalize dtype predicates in type_info

### DIFF
--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -53,7 +53,7 @@ def promote_zero_dims(
                 param_el = param_el.types[idx]  # type: ignore[attr-defined] # checked in condition above
 
             if _is_zero_dim_field(param_el) and (
-                type_info.is_number(arg_el) or type_info.is_logical(arg_el)
+                type_info.is_arithmetic_scalar(arg_el) or type_info.is_logical(arg_el)
             ):
                 if type_info.extract_dtype(param_el) == type_info.extract_dtype(arg_el):
                     return param_el

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -287,7 +287,7 @@ class CollapseTuple(
             and cpm.is_call_to(node.args[1], "make_tuple")
         ):
             # `tuple_get(i, make_tuple(e_0, e_1, ..., e_i, ..., e_N))` -> `e_i`
-            assert not node.args[0].type or type_info.is_integer(node.args[0].type)
+            assert not node.args[0].type or type_info.is_integral_scalar(node.args[0].type)
             make_tuple_call = node.args[1]
             idx = int(node.args[0].value)
             assert idx < len(make_tuple_call.args), (

--- a/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
@@ -190,7 +190,7 @@ def _collect_offset_definitions(
 
 
 def _literal_as_integral_constant(node: itir.Literal) -> IntegralConstant:
-    assert type_info.is_integer(node.type)
+    assert type_info.is_integral_scalar(node.type)
     return IntegralConstant(value=int(node.value))
 
 

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -8,11 +8,12 @@
 
 import functools
 import types
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Collection, Iterable, Iterator
 from typing import Any, Literal, Sequence, Type, TypeGuard, TypeVar, cast, overload
 
 import numpy as np
 
+from gt4py._core import definitions as core_defs
 from gt4py.eve import extended_typing as xtyping, utils
 from gt4py.next import common, utils as next_utils
 from gt4py.next.iterator.type_system import type_specifications as it_ts
@@ -58,15 +59,14 @@ def type_class(symbol_type: ts.TypeSpec) -> Type[ts.TypeSpec]:
     Determine which class should be used to create a compatible concrete type.
 
     Examples:
-    ---------
-    >>> type_class(ts.DeferredType(constraint=ts.ScalarType)).__name__
-    'ScalarType'
+        >>> type_class(ts.DeferredType(constraint=ts.ScalarType)).__name__
+        'ScalarType'
 
-    >>> type_class(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL))).__name__
-    'FieldType'
+        >>> type_class(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL))).__name__
+        'FieldType'
 
-    >>> type_class(ts.TupleType(types=[])).__name__
-    'TupleType'
+        >>> type_class(ts.TupleType(types=[])).__name__
+        'TupleType'
     """
     if isinstance(symbol_type, ts.DeferredType):
         constraint = symbol_type.constraint
@@ -188,12 +188,13 @@ def extract_dtype(symbol_type: ts.TypeSpec) -> ts.ScalarType | ts.ListType:
     Raise an error if no dtype can be found or the result would be ambiguous.
 
     Examples:
-    ---------
-    >>> print(extract_dtype(ts.ScalarType(kind=ts.ScalarKind.FLOAT64)))
-    float64
+        >>> print(extract_dtype(ts.ScalarType(kind=ts.ScalarKind.FLOAT64)))
+        float64
 
-    >>> print(extract_dtype(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL))))
-    bool
+        >>> print(
+        ...     extract_dtype(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL)))
+        ... )
+        bool
     """
     match symbol_type:
         case ts.FieldType(dtype=dtype):
@@ -203,19 +204,17 @@ def extract_dtype(symbol_type: ts.TypeSpec) -> ts.ScalarType | ts.ListType:
     raise ValueError(f"Can not unambiguosly extract data type from '{symbol_type}'.")
 
 
-_FLOATING_POINT_KINDS = (ts.ScalarKind.FLOAT32, ts.ScalarKind.FLOAT64)
-_INTEGRAL_KINDS = (
-    ts.ScalarKind.INT8,
-    ts.ScalarKind.UINT8,
-    ts.ScalarKind.INT16,
-    ts.ScalarKind.UINT16,
-    ts.ScalarKind.INT32,
-    ts.ScalarKind.UINT32,
-    ts.ScalarKind.INT64,
-)
+def _scalar_kinds(scalar_types: tuple[type, ...]) -> frozenset[ts.ScalarKind]:
+    # Derived from the canonical scalar-type tuples in `gt4py._core.definitions` so the two
+    # stay in sync; the `int`/`float` builtins collapse onto their fixed-width kind.
+    return frozenset(ts.ScalarKind[np.dtype(t).name.upper()] for t in scalar_types)
 
 
-def _is_field_or_scalar_of_kind(symbol_type: ts.TypeSpec, kinds: tuple[ts.ScalarKind, ...]) -> bool:
+_FLOATING_POINT_KINDS = _scalar_kinds(core_defs.FLOAT_TYPES)
+_INTEGRAL_KINDS = _scalar_kinds(core_defs.INTEGRAL_TYPES)
+
+
+def _is_field_or_scalar_of_kind(symbol_type: ts.TypeSpec, kinds: Collection[ts.ScalarKind]) -> bool:
     """Check if ``symbol_type`` is a scalar or a field whose dtype kind is in ``kinds``."""
     if not isinstance(symbol_type, (ts.ScalarType, ts.FieldType)):
         return False
@@ -228,31 +227,33 @@ def is_floating_point(symbol_type: ts.TypeSpec) -> bool:
     Check if the dtype of ``symbol_type`` is a floating point type.
 
     Examples:
-    ---------
-    >>> is_floating_point(ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
-    True
-    >>> is_floating_point(ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
-    True
-    >>> is_floating_point(ts.ScalarType(kind=ts.ScalarKind.INT32))
-    False
-    >>> is_floating_point(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32)))
-    True
+        >>> is_floating_point(ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
+        True
+        >>> is_floating_point(ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
+        True
+        >>> is_floating_point(ts.ScalarType(kind=ts.ScalarKind.INT32))
+        False
+        >>> is_floating_point(
+        ...     ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
+        ... )
+        True
     """
     return _is_field_or_scalar_of_kind(symbol_type, _FLOATING_POINT_KINDS)
 
 
-def is_integer(symbol_type: ts.TypeSpec) -> bool:
+def is_integral_scalar(symbol_type: ts.TypeSpec) -> bool:
     """
-    Check if ``symbol_type`` is an integral type.
+    Check if ``symbol_type`` is an integral scalar (rejecting fields).
 
     Examples:
-    ---------
-    >>> is_integer(ts.ScalarType(kind=ts.ScalarKind.INT32))
-    True
-    >>> is_integer(ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
-    False
-    >>> is_integer(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
-    False
+        >>> is_integral_scalar(ts.ScalarType(kind=ts.ScalarKind.INT32))
+        True
+        >>> is_integral_scalar(ts.ScalarType(kind=ts.ScalarKind.UINT64))
+        True
+        >>> is_integral_scalar(ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
+        False
+        >>> is_integral_scalar(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
+        False
     """
     return isinstance(symbol_type, ts.ScalarType) and symbol_type.kind in _INTEGRAL_KINDS
 
@@ -262,36 +263,34 @@ def is_integral(symbol_type: ts.TypeSpec) -> bool:
     Check if the dtype of ``symbol_type`` is an integral type.
 
     Examples:
-    ---------
-    >>> is_integral(ts.ScalarType(kind=ts.ScalarKind.INT32))
-    True
-    >>> is_integral(ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
-    False
-    >>> is_integral(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
-    True
+        >>> is_integral(ts.ScalarType(kind=ts.ScalarKind.INT32))
+        True
+        >>> is_integral(ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
+        False
+        >>> is_integral(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
+        True
     """
     return _is_field_or_scalar_of_kind(symbol_type, _INTEGRAL_KINDS)
 
 
-def is_number(symbol_type: ts.TypeSpec) -> bool:
+def is_arithmetic_scalar(symbol_type: ts.TypeSpec) -> bool:
     """
-    Check if ``symbol_type`` is either intergral or float.
+    Check if ``symbol_type`` is an arithmetic scalar (rejecting fields).
 
     Examples:
-    ---------
-    >>> is_number(ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
-    True
-    >>> is_number(ts.ScalarType(kind=ts.ScalarKind.INT32))
-    True
-    >>> is_number(ts.ScalarType(kind=ts.ScalarKind.BOOL))
-    False
-    >>> is_number(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)))
-    False
+        >>> is_arithmetic_scalar(ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
+        True
+        >>> is_arithmetic_scalar(ts.ScalarType(kind=ts.ScalarKind.INT32))
+        True
+        >>> is_arithmetic_scalar(ts.ScalarType(kind=ts.ScalarKind.BOOL))
+        False
+        >>> is_arithmetic_scalar(
+        ...     ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64))
+        ... )
+        False
     """
     if not isinstance(symbol_type, ts.ScalarType):
         return False
-    # TODO(nfarabullini): re-factor is_arithmetic such that it only checks for scalars
-    #  and the emtpy field pass in an another function
     return is_arithmetic(symbol_type)
 
 
@@ -300,13 +299,12 @@ def is_logical(symbol_type: ts.TypeSpec) -> bool:
     Check if the dtype of ``symbol_type`` is a boolean type.
 
     Examples:
-    ---------
-    >>> is_logical(ts.ScalarType(kind=ts.ScalarKind.BOOL))
-    True
-    >>> is_logical(ts.ScalarType(kind=ts.ScalarKind.INT32))
-    False
-    >>> is_logical(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL)))
-    True
+        >>> is_logical(ts.ScalarType(kind=ts.ScalarKind.BOOL))
+        True
+        >>> is_logical(ts.ScalarType(kind=ts.ScalarKind.INT32))
+        False
+        >>> is_logical(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL)))
+        True
     """
     return _is_field_or_scalar_of_kind(symbol_type, (ts.ScalarKind.BOOL,))
 
@@ -316,15 +314,14 @@ def is_arithmetic(symbol_type: ts.TypeSpec) -> bool:
     Check if ``symbol_type`` is compatible with arithmetic operations.
 
     Examples:
-    ---------
-    >>> is_arithmetic(ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
-    True
-    >>> is_arithmetic(ts.ScalarType(kind=ts.ScalarKind.BOOL))
-    False
-    >>> is_arithmetic(ts.ScalarType(kind=ts.ScalarKind.STRING))
-    False
-    >>> is_arithmetic(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
-    True
+        >>> is_arithmetic(ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
+        True
+        >>> is_arithmetic(ts.ScalarType(kind=ts.ScalarKind.BOOL))
+        False
+        >>> is_arithmetic(ts.ScalarType(kind=ts.ScalarKind.STRING))
+        False
+        >>> is_arithmetic(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
+        True
     """
     return is_floating_point(symbol_type) or is_integral(symbol_type)
 
@@ -350,19 +347,18 @@ def is_type_or_tuple_of_type(type_: ts.TypeSpec, expected_type: type | tuple) ->
     Return True if ``type_`` matches any of the expected or is a tuple of them.
 
     Examples:
-    ---------
-    >>> scalar_type = ts.ScalarType(kind=ts.ScalarKind.INT64)
-    >>> field_type = ts.FieldType(dims=[], dtype=scalar_type)
-    >>> is_type_or_tuple_of_type(field_type, ts.FieldType)
-    True
-    >>> is_type_or_tuple_of_type(
-    ...     ts.TupleType(types=[scalar_type, field_type]), (ts.ScalarType, ts.FieldType)
-    ... )
-    True
-    >>> is_type_or_tuple_of_type(scalar_type, ts.FieldType)
-    False
-    >>> is_type_or_tuple_of_type(ts.TupleType(types=[scalar_type, field_type]), ts.FieldType)
-    False
+        >>> scalar_type = ts.ScalarType(kind=ts.ScalarKind.INT64)
+        >>> field_type = ts.FieldType(dims=[], dtype=scalar_type)
+        >>> is_type_or_tuple_of_type(field_type, ts.FieldType)
+        True
+        >>> is_type_or_tuple_of_type(
+        ...     ts.TupleType(types=[scalar_type, field_type]), (ts.ScalarType, ts.FieldType)
+        ... )
+        True
+        >>> is_type_or_tuple_of_type(scalar_type, ts.FieldType)
+        False
+        >>> is_type_or_tuple_of_type(ts.TupleType(types=[scalar_type, field_type]), ts.FieldType)
+        False
     """
     return all(isinstance(t, expected_type) for t in primitive_constituents(type_))
 
@@ -372,19 +368,18 @@ def is_tuple_of_type(type_: ts.TypeSpec, expected_type: type | tuple) -> TypeGua
     Return True if ``type_`` matches (nested) tuple of ``expected_type``.
 
     Examples:
-    ---------
-    >>> scalar_type = ts.ScalarType(kind=ts.ScalarKind.INT64)
-    >>> field_type = ts.FieldType(dims=[], dtype=scalar_type)
-    >>> is_tuple_of_type(field_type, ts.FieldType)
-    False
-    >>> is_tuple_of_type(
-    ...     ts.TupleType(types=[scalar_type, field_type]), (ts.ScalarType, ts.FieldType)
-    ... )
-    True
-    >>> is_tuple_of_type(ts.TupleType(types=[scalar_type]), ts.FieldType)
-    False
-    >>> is_tuple_of_type(ts.TupleType(types=[scalar_type, field_type]), ts.FieldType)
-    False
+        >>> scalar_type = ts.ScalarType(kind=ts.ScalarKind.INT64)
+        >>> field_type = ts.FieldType(dims=[], dtype=scalar_type)
+        >>> is_tuple_of_type(field_type, ts.FieldType)
+        False
+        >>> is_tuple_of_type(
+        ...     ts.TupleType(types=[scalar_type, field_type]), (ts.ScalarType, ts.FieldType)
+        ... )
+        True
+        >>> is_tuple_of_type(ts.TupleType(types=[scalar_type]), ts.FieldType)
+        False
+        >>> is_tuple_of_type(ts.TupleType(types=[scalar_type, field_type]), ts.FieldType)
+        False
     """
     return isinstance(type_, ts.TupleType) and is_type_or_tuple_of_type(type_, expected_type)
 
@@ -396,13 +391,12 @@ def extract_dims(symbol_type: ts.TypeSpec) -> list[common.Dimension]:
     Scalars are treated as zero-dimensional
 
     Examples:
-    ---------
-    >>> extract_dims(ts.ScalarType(kind=ts.ScalarKind.INT64, shape=[3, 4]))
-    []
-    >>> I = common.Dimension(value="I")
-    >>> J = common.Dimension(value="J")
-    >>> extract_dims(ts.FieldType(dims=[I, J], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)))
-    [Dimension(value='I', kind=<DimensionKind.HORIZONTAL: 'horizontal'>), Dimension(value='J', kind=<DimensionKind.HORIZONTAL: 'horizontal'>)]
+        >>> extract_dims(ts.ScalarType(kind=ts.ScalarKind.INT64, shape=[3, 4]))
+        []
+        >>> I = common.Dimension(value="I")
+        >>> J = common.Dimension(value="J")
+        >>> extract_dims(ts.FieldType(dims=[I, J], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)))
+        [Dimension(value='I', kind=<DimensionKind.HORIZONTAL: 'horizontal'>), Dimension(value='J', kind=<DimensionKind.HORIZONTAL: 'horizontal'>)]
     """
     if isinstance(symbol_type, ts.ScalarType):
         return []
@@ -416,13 +410,14 @@ def is_local_field(type_: ts.FieldType) -> bool:
     Return if `type_` is a field defined on a local dimension.
 
     Examples:
-    ---------
-    >>> V = common.Dimension(value="V")
-    >>> V2E = common.Dimension(value="V2E", kind=common.DimensionKind.LOCAL)
-    >>> is_local_field(ts.FieldType(dims=[V, V2E], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)))
-    True
-    >>> is_local_field(ts.FieldType(dims=[V], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)))
-    False
+        >>> V = common.Dimension(value="V")
+        >>> V2E = common.Dimension(value="V2E", kind=common.DimensionKind.LOCAL)
+        >>> is_local_field(
+        ...     ts.FieldType(dims=[V, V2E], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64))
+        ... )
+        True
+        >>> is_local_field(ts.FieldType(dims=[V], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)))
+        False
     """
     return any(dim.kind == common.DimensionKind.LOCAL for dim in type_.dims)
 
@@ -515,41 +510,41 @@ def is_concretizable(symbol_type: ts.TypeSpec, to_type: ts.TypeSpec) -> bool:
     Check if ``symbol_type`` can be concretized to ``to_type``.
 
     Examples:
-    ---------
-    >>> is_concretizable(
-    ...     ts.ScalarType(kind=ts.ScalarKind.INT64), to_type=ts.ScalarType(kind=ts.ScalarKind.INT64)
-    ... )
-    True
+        >>> is_concretizable(
+        ...     ts.ScalarType(kind=ts.ScalarKind.INT64),
+        ...     to_type=ts.ScalarType(kind=ts.ScalarKind.INT64),
+        ... )
+        True
 
-    >>> is_concretizable(
-    ...     ts.ScalarType(kind=ts.ScalarKind.INT64),
-    ...     to_type=ts.ScalarType(kind=ts.ScalarKind.FLOAT64),
-    ... )
-    False
+        >>> is_concretizable(
+        ...     ts.ScalarType(kind=ts.ScalarKind.INT64),
+        ...     to_type=ts.ScalarType(kind=ts.ScalarKind.FLOAT64),
+        ... )
+        False
 
-    >>> is_concretizable(
-    ...     ts.DeferredType(constraint=None),
-    ...     to_type=ts.FieldType(dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL), dims=[]),
-    ... )
-    True
+        >>> is_concretizable(
+        ...     ts.DeferredType(constraint=None),
+        ...     to_type=ts.FieldType(dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL), dims=[]),
+        ... )
+        True
 
-    >>> is_concretizable(
-    ...     ts.DeferredType(constraint=ts.DataType),
-    ...     to_type=ts.FieldType(dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL), dims=[]),
-    ... )
-    True
+        >>> is_concretizable(
+        ...     ts.DeferredType(constraint=ts.DataType),
+        ...     to_type=ts.FieldType(dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL), dims=[]),
+        ... )
+        True
 
-    >>> is_concretizable(
-    ...     ts.DeferredType(constraint=ts.OffsetType),
-    ...     to_type=ts.FieldType(dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL), dims=[]),
-    ... )
-    False
+        >>> is_concretizable(
+        ...     ts.DeferredType(constraint=ts.OffsetType),
+        ...     to_type=ts.FieldType(dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL), dims=[]),
+        ... )
+        False
 
-    >>> is_concretizable(
-    ...     ts.DeferredType(constraint=ts.TypeSpec),
-    ...     to_type=ts.DeferredType(constraint=ts.ScalarType),
-    ... )
-    True
+        >>> is_concretizable(
+        ...     ts.DeferredType(constraint=ts.TypeSpec),
+        ...     to_type=ts.DeferredType(constraint=ts.ScalarType),
+        ... )
+        True
 
     """
     if isinstance(symbol_type, ts.DeferredType) and (

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -9,7 +9,7 @@
 import functools
 import types
 from collections.abc import Callable, Collection, Iterable, Iterator
-from typing import Any, Literal, Sequence, Type, TypeGuard, TypeVar, cast, overload
+from typing import Any, Final, Literal, Sequence, Type, TypeGuard, TypeVar, cast, overload
 
 import numpy as np
 
@@ -210,8 +210,8 @@ def _scalar_kinds(scalar_types: tuple[type, ...]) -> frozenset[ts.ScalarKind]:
     return frozenset(ts.ScalarKind[np.dtype(t).name.upper()] for t in scalar_types)
 
 
-_FLOATING_POINT_KINDS = _scalar_kinds(core_defs.FLOAT_TYPES)
-_INTEGRAL_KINDS = _scalar_kinds(core_defs.INTEGRAL_TYPES)
+_FLOATING_POINT_KINDS: Final[frozenset[ts.ScalarKind]] = _scalar_kinds(core_defs.FLOAT_TYPES)
+_INTEGRAL_KINDS: Final[frozenset[ts.ScalarKind]] = _scalar_kinds(core_defs.INTEGRAL_TYPES)
 
 
 def _is_field_or_scalar_of_kind(symbol_type: ts.TypeSpec, kinds: Collection[ts.ScalarKind]) -> bool:

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -203,6 +203,26 @@ def extract_dtype(symbol_type: ts.TypeSpec) -> ts.ScalarType | ts.ListType:
     raise ValueError(f"Can not unambiguosly extract data type from '{symbol_type}'.")
 
 
+_FLOATING_POINT_KINDS = (ts.ScalarKind.FLOAT32, ts.ScalarKind.FLOAT64)
+_INTEGRAL_KINDS = (
+    ts.ScalarKind.INT8,
+    ts.ScalarKind.UINT8,
+    ts.ScalarKind.INT16,
+    ts.ScalarKind.UINT16,
+    ts.ScalarKind.INT32,
+    ts.ScalarKind.UINT32,
+    ts.ScalarKind.INT64,
+)
+
+
+def _is_field_or_scalar_of_kind(symbol_type: ts.TypeSpec, kinds: tuple[ts.ScalarKind, ...]) -> bool:
+    """Check if ``symbol_type`` is a scalar or a field whose dtype kind is in ``kinds``."""
+    if not isinstance(symbol_type, (ts.ScalarType, ts.FieldType)):
+        return False
+    dtype = extract_dtype(symbol_type)
+    return isinstance(dtype, ts.ScalarType) and dtype.kind in kinds
+
+
 def is_floating_point(symbol_type: ts.TypeSpec) -> bool:
     """
     Check if the dtype of ``symbol_type`` is a floating point type.
@@ -218,12 +238,7 @@ def is_floating_point(symbol_type: ts.TypeSpec) -> bool:
     >>> is_floating_point(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32)))
     True
     """
-    if not isinstance(symbol_type, (ts.ScalarType, ts.FieldType)):
-        return False
-    return isinstance(dtype := extract_dtype(symbol_type), ts.ScalarType) and dtype.kind in [
-        ts.ScalarKind.FLOAT32,
-        ts.ScalarKind.FLOAT64,
-    ]
+    return _is_field_or_scalar_of_kind(symbol_type, _FLOATING_POINT_KINDS)
 
 
 def is_integer(symbol_type: ts.TypeSpec) -> bool:
@@ -239,15 +254,7 @@ def is_integer(symbol_type: ts.TypeSpec) -> bool:
     >>> is_integer(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
     False
     """
-    return isinstance(symbol_type, ts.ScalarType) and symbol_type.kind in {
-        ts.ScalarKind.INT8,
-        ts.ScalarKind.UINT8,
-        ts.ScalarKind.INT16,
-        ts.ScalarKind.UINT16,
-        ts.ScalarKind.INT32,
-        ts.ScalarKind.UINT32,
-        ts.ScalarKind.INT64,
-    }
+    return isinstance(symbol_type, ts.ScalarType) and symbol_type.kind in _INTEGRAL_KINDS
 
 
 def is_integral(symbol_type: ts.TypeSpec) -> bool:
@@ -263,9 +270,7 @@ def is_integral(symbol_type: ts.TypeSpec) -> bool:
     >>> is_integral(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)))
     True
     """
-    if not isinstance(symbol_type, (ts.ScalarType, ts.FieldType)):
-        return False
-    return is_integer(extract_dtype(symbol_type))
+    return _is_field_or_scalar_of_kind(symbol_type, _INTEGRAL_KINDS)
 
 
 def is_number(symbol_type: ts.TypeSpec) -> bool:
@@ -291,11 +296,19 @@ def is_number(symbol_type: ts.TypeSpec) -> bool:
 
 
 def is_logical(symbol_type: ts.TypeSpec) -> bool:
-    return (
-        isinstance(symbol_type, (ts.FieldType, ts.ScalarType))
-        and isinstance(dtype := extract_dtype(symbol_type), ts.ScalarType)
-        and dtype.kind is ts.ScalarKind.BOOL
-    )
+    """
+    Check if the dtype of ``symbol_type`` is a boolean type.
+
+    Examples:
+    ---------
+    >>> is_logical(ts.ScalarType(kind=ts.ScalarKind.BOOL))
+    True
+    >>> is_logical(ts.ScalarType(kind=ts.ScalarKind.INT32))
+    False
+    >>> is_logical(ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL)))
+    True
+    """
+    return _is_field_or_scalar_of_kind(symbol_type, (ts.ScalarKind.BOOL,))
 
 
 def is_arithmetic(symbol_type: ts.TypeSpec) -> bool:

--- a/src/gt4py/next/type_system/type_translation.py
+++ b/src/gt4py/next/type_system/type_translation.py
@@ -212,7 +212,7 @@ def from_type_hint(
                     f"Field dtype argument must be a scalar type (got '{dtype_arg}')."
                 ) from error
             if not isinstance(dtype, ts.ScalarType) or dtype.kind == ts.ScalarKind.STRING:
-                raise ValueError("Field dtype argument must be a scalar type (got '{dtype}').")
+                raise ValueError(f"Field dtype argument must be a scalar type (got '{dtype}').")
             return ts.FieldType(dims=dims, dtype=dtype)
 
         case collections.abc.Callable:


### PR DESCRIPTION
**Stack 1/4 — dtype-generic field operators.** Base: \`main\`.

Pre-cleanup so the feature lands on clean ground. Routes the field-aware dtype
predicates (\`is_floating_point\`/\`is_integral\`/\`is_logical\`) through a single
\`_is_field_or_scalar_of_kind\` helper and shares the integral-kind set with
\`is_integer\`, so the per-predicate dtype-extraction logic lives in one place. Adds a
docstring/doctests to \`is_logical\`, and fixes a latent non-f-string error message in
\`type_translation.from_type_hint\` that printed the literal \`{dtype}\`.

Behavior-preserving (pinned by the existing \`type_info\` doctests). Inert refactor.

---
Stacked PR series (review/merge in order):
1. **predicate cleanup** ← this PR (→ main)
2. dtype-generic type system foundations (Stage 0) + ADR 0023
3. dtype-generic field operators (Stage 1)
4. generic operators called from programs (Stage 2)