### PR TITLE
feat[next]: generic operators called from programs (Stage 2)

### DIFF
--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -44,6 +44,7 @@ from gt4py.next.ffront import (
     type_info as ffront_type_info,
     type_specifications as ts_ffront,
 )
+from gt4py.next.ffront.foast_passes.specialize_type_vars import specialize_and_rename
 from gt4py.next.ffront.gtcallable import GTCallable
 from gt4py.next.instrumentation import hook_machinery, metrics
 from gt4py.next.iterator import ir as itir
@@ -642,6 +643,19 @@ class FieldOperator(_CompilableGTEntryPointMixin[ffront_stages.DSLFieldOperatorD
 
     def __gt_closure_vars__(self) -> dict[str, Any]:
         return self.foast_stage.closure_vars
+
+    def __gt_specialize__(self, binding: dict[str, ts.ScalarType], name: str) -> GTCallable:
+        # local import to avoid a module import cycle (foast_to_past imports decorator transitively)
+        from gt4py.next.ffront import foast_to_past
+
+        renamed = specialize_and_rename(self.foast_stage.foast_node, binding, name)
+        new_stage = dataclasses.replace(self.foast_stage, foast_node=renamed)
+        return foast_to_past.ItirShim(
+            definition=toolchain.ConcreteArtifact(
+                data=new_stage, args=arguments.CompileTimeArgs.empty()
+            ),
+            foast_to_itir=foast_to_gtir.adapted_foast_to_gtir_factory(),
+        )
 
     def __call__(self, *args: Any, enable_jit: bool | None = None, **kwargs: Any) -> Any:
         if not next_embedded.context.within_valid_context() and self.backend is not None:

--- a/src/gt4py/next/ffront/foast_passes/specialize_type_vars.py
+++ b/src/gt4py/next/ffront/foast_passes/specialize_type_vars.py
@@ -8,12 +8,28 @@
 
 from typing import Any, Mapping, TypeVar
 
-from gt4py.eve import NodeTranslator
+from gt4py.eve import NodeTranslator, datamodels
 from gt4py.next.ffront import field_operator_ast as foast, type_specifications as ts_ffront
 from gt4py.next.type_system import type_info, type_specifications as ts
 
 
 _NodeT = TypeVar("_NodeT", bound=foast.LocatedNode)
+_OperatorNodeT = TypeVar("_OperatorNodeT", bound=foast.OperatorNode)
+
+
+def specialize_and_rename(
+    node: _OperatorNodeT, binding: Mapping[str, ts.ScalarType], name: str
+) -> _OperatorNodeT:
+    """Specialize a generic operator's FOAST tree and rename it (for monomorphization).
+
+    The rename gives each per-binding variant a distinct identity so that the lowering
+    produces one ``itir.FunctionDefinition`` per variant.
+    """
+    specialized = SpecializeTypeVars.apply(node, binding)
+    if isinstance(specialized, (foast.FieldOperator, foast.ScanOperator)):
+        new_definition = datamodels.evolve(specialized.definition, id=name)
+        return datamodels.evolve(specialized, id=name, definition=new_definition)
+    return datamodels.evolve(specialized, id=name)
 
 
 class SpecializeTypeVars(NodeTranslator):

--- a/src/gt4py/next/ffront/foast_to_past.py
+++ b/src/gt4py/next/ffront/foast_to_past.py
@@ -17,6 +17,7 @@ from gt4py.next.ffront import (
     type_info as ffront_type_info,
     type_specifications as ts_ffront,
 )
+from gt4py.next.ffront.foast_passes.specialize_type_vars import specialize_and_rename
 from gt4py.next.ffront.past_passes import closure_var_type_deduction, type_deduction
 from gt4py.next.ffront.stages import ConcreteFOASTOperatorDef, ConcretePASTProgramDef
 from gt4py.next.iterator import ir as itir
@@ -38,6 +39,14 @@ class ItirShim:
 
     def __gt_closure_vars__(self) -> Optional[dict[str, Any]]:
         return self.definition.data.closure_vars
+
+    def __gt_specialize__(self, binding: dict[str, ts.ScalarType], name: str) -> "ItirShim":
+        renamed = specialize_and_rename(self.definition.data.foast_node, binding, name)
+        new_data = dataclasses.replace(self.definition.data, foast_node=renamed)
+        return ItirShim(
+            definition=dataclasses.replace(self.definition, data=new_data),
+            foast_to_itir=self.foast_to_itir,
+        )
 
     def __gt_type__(self) -> ts.CallableType:
         assert isinstance(self.definition.data.foast_node.type, ts.CallableType)

--- a/src/gt4py/next/ffront/gtcallable.py
+++ b/src/gt4py/next/ffront/gtcallable.py
@@ -32,6 +32,18 @@ class GTCallable(typing.Protocol):
         """
         return None
 
+    def __gt_specialize__(self, binding: dict[str, ts.ScalarType], name: str) -> "GTCallable":
+        """
+        Return a concrete (monomorphic) copy of a generic callable, named ``name``.
+
+        Only meaningful for generic callables (e.g. dtype-generic field operators); the
+        type variables of the signature are substituted according to ``binding``. Used by
+        the program lowering to produce one variant per call-site binding.
+        """
+        raise NotImplementedError(
+            f"'{type(self).__name__}' does not support specialization of generic operators."
+        )
+
     @abc.abstractmethod
     def __gt_type__(self) -> ts.CallableType:
         """

--- a/src/gt4py/next/ffront/past_passes/monomorphize_generic_calls.py
+++ b/src/gt4py/next/ffront/past_passes/monomorphize_generic_calls.py
@@ -1,0 +1,97 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Monomorphize calls to dtype-generic field operators inside a PAST program.
+
+For every call to a generic operator the type variables are bound from the concrete
+call-site argument types, the callee is name-mangled per binding, and a specialized
+(monomorphic) callable is put into the closure variables under the mangled name. The
+program lowering then produces one ``itir.FunctionDefinition`` per binding.
+"""
+
+from typing import Any
+
+from gt4py.eve import NodeTranslator, datamodels
+from gt4py.next.ffront import (
+    program_ast as past,
+    type_info as ffront_type_info,
+    type_specifications as ts_ffront,
+)
+from gt4py.next.ffront.gtcallable import GTCallable
+from gt4py.next.type_system import type_info, type_specifications as ts
+
+
+def _mangle_name(name: str, binding: dict[str, ts.ScalarType]) -> str:
+    suffix = "_".join(f"{var}_{dtype}" for var, dtype in sorted(binding.items()))
+    return f"{name}__{suffix}"
+
+
+class _MonomorphizeGenericCalls(NodeTranslator):
+    def __init__(self, closure_vars: dict[str, Any]):
+        super().__init__()
+        self.closure_vars = closure_vars
+        self.specialized: dict[str, GTCallable] = {}
+
+    def visit_Call(self, node: past.Call, **kwargs: Any) -> past.Call:
+        node = self.generic_visit(node, **kwargs)
+        func_type = node.func.type
+        # generic scan operators are rejected at decoration time, so only field operators
+        # can be generic here
+        if not (
+            isinstance(func_type, ts_ffront.FieldOperatorType) and type_info.is_generic(func_type)
+        ):
+            return node
+        callee = self.closure_vars.get(node.func.id)
+        if not isinstance(callee, GTCallable):
+            return node
+
+        # argument types are concrete after program type deduction
+        arg_types: list[ts.TypeSpec] = []
+        for arg in node.args:
+            assert arg.type is not None
+            arg_types.append(arg.type)
+        kwarg_types: dict[str, ts.TypeSpec] = {}
+        for name, expr in node.kwargs.items():
+            if name not in ("out", "domain"):
+                assert expr.type is not None
+                kwarg_types[name] = expr.type
+        binding = ffront_type_info.bind_fieldop_type_vars(func_type, arg_types, kwarg_types)
+        if not binding:
+            return node
+
+        mangled = _mangle_name(node.func.id, binding)
+        if mangled not in self.specialized:
+            self.specialized[mangled] = callee.__gt_specialize__(binding, mangled)
+
+        new_func = datamodels.evolve(
+            node.func, id=mangled, type=self.specialized[mangled].__gt_type__()
+        )
+        return datamodels.evolve(node, func=new_func)
+
+
+def monomorphize_generic_calls(
+    past_node: past.Program, closure_vars: dict[str, Any]
+) -> tuple[past.Program, dict[str, Any]]:
+    """Rewrite generic operator calls to mangled, monomorphic callees.
+
+    Returns the (possibly rewritten) program node together with closure variables in which
+    every called generic operator has been replaced by its per-binding specializations.
+    """
+    pass_ = _MonomorphizeGenericCalls(closure_vars)
+    new_node = pass_.visit(past_node)
+    if not pass_.specialized:
+        return past_node, closure_vars
+
+    # drop the generic callables (they can not be lowered) and add the specialized variants
+    new_closure_vars = {
+        name: value
+        for name, value in closure_vars.items()
+        if not (isinstance(value, GTCallable) and type_info.is_generic(value.__gt_type__()))
+    }
+    new_closure_vars.update(pass_.specialized)
+    return new_node, new_closure_vars

--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -25,6 +25,7 @@ from gt4py.next.ffront import (
     type_info as ffront_ti,
     type_specifications as ts_ffront,
 )
+from gt4py.next.ffront.past_passes.monomorphize_generic_calls import monomorphize_generic_calls
 from gt4py.next.ffront.stages import ConcretePASTProgramDef
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
@@ -72,7 +73,11 @@ def past_to_gtir(inp: ConcretePASTProgramDef) -> definitions.CompilableProgramDe
         >>> print(type(itir_copy.data))
         <class 'gt4py.next.iterator.ir.Program'>
     """
-    all_closure_vars = transform_utils._get_closure_vars_recursively(inp.data.closure_vars)
+    # monomorphize calls to dtype-generic operators: bind type variables per call site,
+    # name-mangle the callee, and replace it by a concrete specialization in the closure vars
+    past_node, closure_vars = monomorphize_generic_calls(inp.data.past_node, inp.data.closure_vars)
+
+    all_closure_vars = transform_utils._get_closure_vars_recursively(closure_vars)
     offsets_and_dimensions = transform_utils._filter_closure_vars_by_type(
         all_closure_vars, fbuiltins.FieldOffset, common.Dimension
     )
@@ -94,7 +99,7 @@ def past_to_gtir(inp: ConcretePASTProgramDef) -> definitions.CompilableProgramDe
         lowered_funcs.append(gt_callable.__gt_gtir__())
 
     itir_program = ProgramLowering.apply(
-        inp.data.past_node, function_definitions=lowered_funcs, grid_type=grid_type
+        past_node, function_definitions=lowered_funcs, grid_type=grid_type
     )
 
     # TODO(tehrengruber): Put this in a dedicated transformation step.

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -81,6 +81,48 @@ def promote_zero_dims(
     return tuple(new_args), new_kwargs
 
 
+def bind_fieldop_type_vars(
+    fieldop_type: ts_ffront.FieldOperatorType,
+    args: Sequence[ts.TypeSpec],
+    kwargs: dict[str, ts.TypeSpec],
+) -> dict[str, ts.ScalarType]:
+    """Bind the type variables of a generic field operator from concrete call arguments.
+
+    Mirrors the argument alignment of `promote_zero_dims`: after canonicalization the
+    positional arguments line up with the positional parameters and the remaining keyword
+    arguments with the keyword-only parameters.
+    """
+    definition = fieldop_type.definition
+    cargs, ckwargs = type_info.canonicalize_arguments(
+        fieldop_type, args, kwargs, ignore_errors=True
+    )
+    param_types: list[ts.TypeSpec] = [
+        *definition.pos_only_args,
+        *definition.pos_or_kw_args.values(),
+    ]
+    arg_types: list[ts.TypeSpec] = list(cargs)
+    for name, arg_type in ckwargs.items():
+        if name in definition.kw_only_args:
+            param_types.append(definition.kw_only_args[name])
+            arg_types.append(arg_type)
+    return type_info.bind_type_vars(param_types, arg_types)
+
+
+def _specialized_fieldop_definition(
+    fieldop_type: ts_ffront.FieldOperatorType,
+    args: Sequence[ts.TypeSpec],
+    kwargs: dict[str, ts.TypeSpec],
+) -> ts.FunctionType:
+    """Substitute the field operator's type variables from the call arguments (no-op if concrete)."""
+    definition = fieldop_type.definition
+    if not type_info.is_generic(definition):
+        return definition
+    binding = bind_fieldop_type_vars(fieldop_type, args, kwargs)
+    specialized = type_info.substitute_type_vars(definition, binding)
+    assert isinstance(specialized, ts.FunctionType)
+    return specialized
+
+
 @type_info.return_type.register
 def return_type_fieldop(
     fieldop_type: ts_ffront.FieldOperatorType,
@@ -88,9 +130,8 @@ def return_type_fieldop(
     with_args: list[ts.TypeSpec],
     with_kwargs: dict[str, ts.TypeSpec],
 ) -> ts.TypeSpec:
-    ret_type = type_info.return_type(
-        fieldop_type.definition, with_args=with_args, with_kwargs=with_kwargs
-    )
+    definition = _specialized_fieldop_definition(fieldop_type, with_args, with_kwargs)
+    ret_type = type_info.return_type(definition, with_args=with_args, with_kwargs=with_kwargs)
     return ret_type
 
 
@@ -134,22 +175,28 @@ def function_signature_incompatibilities_fieldop(
     args: Sequence[ts.TypeSpec],
     kwargs: dict[str, ts.TypeSpec],
 ) -> Iterator[str]:
-    args, kwargs = type_info.canonicalize_arguments(
-        fieldop_type.definition, args, kwargs, ignore_errors=True
-    )
+    if type_info.is_generic(fieldop_type.definition):
+        try:
+            definition = _specialized_fieldop_definition(fieldop_type, args, kwargs)
+        except ValueError as err:
+            # inconsistent / out-of-constraint type variable binding
+            yield str(err)
+            return
+    else:
+        definition = fieldop_type.definition
+
+    args, kwargs = type_info.canonicalize_arguments(definition, args, kwargs, ignore_errors=True)
 
     error_list = list(
-        type_info.structural_function_signature_incompatibilities(
-            fieldop_type.definition, args, kwargs
-        )
+        type_info.structural_function_signature_incompatibilities(definition, args, kwargs)
     )
     if len(error_list) > 0:
         yield from error_list
         return
 
-    new_args, new_kwargs = promote_zero_dims(fieldop_type.definition, args, kwargs)
+    new_args, new_kwargs = promote_zero_dims(definition, args, kwargs)
     yield from type_info.function_signature_incompatibilities_func(
-        fieldop_type.definition, new_args, new_kwargs, skip_canonicalization=True
+        definition, new_args, new_kwargs, skip_canonicalization=True
     )
 
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_generic_dtype_operators.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_generic_dtype_operators.py
@@ -126,6 +126,37 @@ def test_generic_tuple_return(cartesian_case):
         assert out[0].asnumpy().dtype == dtype
 
 
+def test_generic_operator_called_in_program(cartesian_case):
+    @gtx.field_operator
+    def diff(
+        a: gtx.Field[gtx.Dims[IDim], FloatT], b: gtx.Field[gtx.Dims[IDim], FloatT]
+    ) -> gtx.Field[gtx.Dims[IDim], FloatT]:
+        return a - b
+
+    @gtx.program
+    def diff_program(
+        a32: gtx.Field[gtx.Dims[IDim], gtx.float32],
+        b32: gtx.Field[gtx.Dims[IDim], gtx.float32],
+        out32: gtx.Field[gtx.Dims[IDim], gtx.float32],
+        a64: gtx.Field[gtx.Dims[IDim], gtx.float64],
+        b64: gtx.Field[gtx.Dims[IDim], gtx.float64],
+        out64: gtx.Field[gtx.Dims[IDim], gtx.float64],
+    ):
+        # the same generic operator is instantiated at two dtypes in one program
+        diff(a32, b32, out=out32)
+        diff(a64, b64, out=out64)
+
+    a32, b32, out32 = _allocate_diff_args(cartesian_case, np.float32)
+    a64, b64, out64 = _allocate_diff_args(cartesian_case, np.float64)
+
+    cases.run(cartesian_case, diff_program, a32, b32, out32, a64, b64, out64)
+
+    assert out32.asnumpy().dtype == np.float32
+    assert np.allclose(out32.asnumpy(), a32.asnumpy() - b32.asnumpy())
+    assert out64.asnumpy().dtype == np.float64
+    assert np.allclose(out64.asnumpy(), a64.asnumpy() - b64.asnumpy())
+
+
 def test_generic_math_builtin(cartesian_case):
     @gtx.field_operator
     def generic_sin(a: gtx.Field[gtx.Dims[IDim], FloatT]) -> gtx.Field[gtx.Dims[IDim], FloatT]:

--- a/tests/next_tests/unit_tests/ffront_tests/test_past_to_gtir.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_past_to_gtir.py
@@ -238,3 +238,45 @@ def test_invalid_call_sig_program(invalid_call_sig_program_def):
         re.search(r"Missing required keyword argument 'out'", exc_info.value.__cause__.args[0])
         is not None
     )
+
+
+def test_generic_operator_monomorphized_per_binding():
+    """A generic operator called at two dtypes in one program lowers to two function defs."""
+    import typing
+
+    from gt4py.next.ffront.past_to_itir import past_to_gtir
+    from gt4py.next.otf import arguments, toolchain
+
+    FloatT = typing.TypeVar("FloatT", gtx.float32, gtx.float64)
+
+    @gtx.field_operator
+    def diff(
+        a: gtx.Field[gtx.Dims[IDim], FloatT], b: gtx.Field[gtx.Dims[IDim], FloatT]
+    ) -> gtx.Field[gtx.Dims[IDim], FloatT]:
+        return a - b
+
+    @gtx.program
+    def prog(
+        a32: gtx.Field[gtx.Dims[IDim], gtx.float32],
+        b32: gtx.Field[gtx.Dims[IDim], gtx.float32],
+        o32: gtx.Field[gtx.Dims[IDim], gtx.float32],
+        a64: gtx.Field[gtx.Dims[IDim], gtx.float64],
+        b64: gtx.Field[gtx.Dims[IDim], gtx.float64],
+        o64: gtx.Field[gtx.Dims[IDim], gtx.float64],
+    ):
+        diff(a32, b32, out=o32)
+        diff(a64, b64, out=o64)
+
+    compile_time_args = arguments.CompileTimeArgs(
+        args=tuple(param.type for param in prog.past_stage.past_node.params),
+        kwargs={},
+        offset_provider={"I": IDim},
+        column_axis=None,
+        argument_descriptor_contexts={},
+    )
+    lowered = past_to_gtir(toolchain.ConcreteArtifact(prog.past_stage, compile_time_args))
+
+    fundef_ids = sorted(str(fundef.id) for fundef in lowered.data.function_definitions)
+    assert len(fundef_ids) == 2
+    assert all(fid.startswith("diff__") for fid in fundef_ids)
+    assert fundef_ids[0] != fundef_ids[1]


### PR DESCRIPTION
**Stack 4/4 — dtype-generic field operators.** Base: \`dtype-generics-3-field-operators\` (#64).

A dtype-generic field operator can now be called from a concrete \`@program\`, including at
several dtypes in one program.

- **Type-checking:** \`return_type_fieldop\` and \`function_signature_incompatibilities_fieldop\`
  bind the operator's type variables from the concrete call arguments and substitute *before*
  the existing checks (so zero-dim promotion only ever sees concrete types — this also obviated
  a separately-planned \`promote_zero_dims\` change).
- **Lowering:** a new PAST pass \`monomorphize_generic_calls\` binds each call site, name-mangles
  the callee per binding (e.g. \`diff__FloatT_float32\`), and replaces the generic closure
  callable with concrete specializations via a new \`GTCallable.__gt_specialize__(binding, name)\`
  (implemented by \`FieldOperator\` and \`ItirShim\` using the \`SpecializeTypeVars\` FOAST pass +
  rename). Two bindings of one operator become two GTIR \`FunctionDefinition\`s.

Calling a generic operator **from another operator** remains a follow-up. Verified across the
backend matrix incl. **GPU** (a program instantiating one operator at float32 and float64).

---
Stacked: 1 (#62) → 2 (#63) → 3 (#64) → **4 this**. Review/merge in order; this is the tip.