### PR TITLE
prototype[next]: collapse CompilationArtifact to one dataclass + per-build loader file

### DIFF
--- a/src/gt4py/next/otf/compilation/compiler.py
+++ b/src/gt4py/next/otf/compilation/compiler.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
+import textwrap
 from typing import Protocol, TypeVar
 
 from gt4py._core import definitions as core_defs, locking
 from gt4py.next import config
 from gt4py.next.otf import code_specs, definitions, stages, workflow
-from gt4py.next.otf.compilation import build_data, cache, importer
+from gt4py.next.otf.compilation import build_data, cache
 
 
 def is_compiled(data: build_data.BuildData) -> bool:
@@ -40,47 +41,20 @@ class BuildSystemProjectGenerator(Protocol[CodeSpecT, TargetCodeSpecT]):
 
 
 @dataclasses.dataclass(frozen=True)
-class CPPCompilationArtifact:
-    """On-disk result of a CPP-style compilation: a Python extension module.
-
-    The default ``load`` is an ``importlib`` import + entry-point lookup;
-    backends override to apply their own calling convention.
-    """
-
-    src_dir: pathlib.Path
-    module: pathlib.Path
-    entry_point_name: str
-    device_type: core_defs.DeviceType
-
-    def load(self) -> stages.ExecutableProgram:
-        """Import the .so and return the raw entry point.
-
-        Must run in the process that will call the returned program: the
-        module is registered in that process's ``sys.modules`` under the
-        ``gt4py.__compiled_programs__.`` prefix.
-        """
-        m = importer.import_from_path(
-            self.src_dir / self.module,
-            sys_modules_prefix="gt4py.__compiled_programs__.",
-        )
-        return getattr(m, self.entry_point_name)
-
-
-@dataclasses.dataclass(frozen=True)
 class CPPCompiler(
     workflow.ChainableWorkflowMixin[
         stages.CompilableProject[CPPLikeCodeSpecT, code_specs.PythonCodeSpec],
-        CPPCompilationArtifact,
+        stages.CompilationArtifact,
     ],
     workflow.ReplaceEnabledWorkflowMixin[
         stages.CompilableProject[CPPLikeCodeSpecT, code_specs.PythonCodeSpec],
-        CPPCompilationArtifact,
+        stages.CompilationArtifact,
     ],
     definitions.CompilationStep[CPPLikeCodeSpecT, code_specs.PythonCodeSpec],
 ):
-    """Drive a CPP-style build system into a ``CPPCompilationArtifact``.
+    """Drive a CPP-style build system and write a ``_gt4py_load.py`` next to the .so.
 
-    Backends override ``_make_artifact`` to use their own artifact subclass.
+    Backends override ``_render_loader`` to emit their own loader-file body.
     """
 
     cache_lifetime: config.BuildCacheLifetime
@@ -91,7 +65,7 @@ class CPPCompiler(
     def __call__(
         self,
         inp: stages.CompilableProject[CPPLikeCodeSpecT, code_specs.PythonCodeSpec],
-    ) -> CPPCompilationArtifact:
+    ) -> stages.CompilationArtifact:
         src_dir = cache.get_cache_folder(inp, self.cache_lifetime)
 
         # If we are compiling the same program at the same time (e.g. multiple MPI ranks),
@@ -109,17 +83,24 @@ class CPPCompiler(
                     f"On-the-fly compilation unsuccessful for '{inp.program_source.entry_point.name}'."
                 )
 
-        return self._make_artifact(src_dir, new_data.module, new_data.entry_point_name)
+            (src_dir / stages._LOADER_MODULE_FILENAME).write_text(
+                self._render_loader(new_data.module, new_data.entry_point_name)
+            )
 
-    def _make_artifact(
-        self, src_dir: pathlib.Path, module: pathlib.Path, entry_point_name: str
-    ) -> CPPCompilationArtifact:
-        return CPPCompilationArtifact(
-            src_dir=src_dir,
-            module=module,
-            entry_point_name=entry_point_name,
-            device_type=self.device_type,
-        )
+        return stages.CompilationArtifact(src_dir=src_dir)
+
+    def _render_loader(self, module: pathlib.Path, entry_point_name: str) -> str:
+        return textwrap.dedent(f"""\
+            from gt4py.next.otf.compilation import importer
+
+
+            def load(src_dir):
+                m = importer.import_from_path(
+                    src_dir / {str(module)!r},
+                    sys_modules_prefix="gt4py.__compiled_programs__.",
+                )
+                return getattr(m, {entry_point_name!r})
+            """)
 
 
 class CompilationError(RuntimeError): ...

--- a/src/gt4py/next/otf/stages.py
+++ b/src/gt4py/next/otf/stages.py
@@ -9,17 +9,10 @@
 from __future__ import annotations
 
 import dataclasses
+import importlib.util
+import pathlib
 from collections.abc import Callable
-from typing import (
-    TYPE_CHECKING,
-    Final,
-    Generic,
-    Optional,
-    Protocol,
-    TypeAlias,
-    TypeVar,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Final, Generic, Optional, Protocol, TypeAlias, TypeVar
 
 from gt4py.next import common, fingerprinting
 from gt4py.next.iterator import ir as itir
@@ -138,23 +131,31 @@ class BuildSystemProject(Protocol[CodeSpecT_co, TargetCodeSpecT_co]):
 ExecutableProgram: TypeAlias = Callable
 
 
-@runtime_checkable
-class CompilationArtifact(Protocol):
-    """The output of an ``OTFCompileWorkflow``.
+_LOADER_MODULE_FILENAME: Final[str] = "_gt4py_load.py"
 
-    Each backend defines its own concrete artifact dataclass; all share this
-    Protocol. Implementations are frozen dataclasses, picklable, and carry no
-    live process-bound state — that is reconstructed by ``load``, which
-    returns a directly-callable ``ExecutableProgram`` taking gt4py-shaped
-    arguments.
 
-    The one current exception is ``RoundtripArtifact`` when it is configured
-    with a ``dispatch_backend``: that field holds a ``Backend`` reference
-    whose role belongs at the runner / load-time seam, not in the artifact
-    itself.
+@dataclasses.dataclass(frozen=True)
+class CompilationArtifact:
+    """An on-disk compiled program addressable by its build folder.
+
+    Each backend writes a ``_gt4py_load.py`` into the build folder at compile time;
+    that file exposes a ``load(src_dir: pathlib.Path) -> ExecutableProgram`` function
+    encoding the backend-specific loading logic (importing the .so, deserializing the
+    SDFG, exec'ing source, …). ``CompilationArtifact.load`` execs that file and
+    delegates.
     """
 
-    def load(self) -> ExecutableProgram: ...
+    src_dir: pathlib.Path
+
+    def load(self) -> ExecutableProgram:
+        loader_path = self.src_dir / _LOADER_MODULE_FILENAME
+        spec = importlib.util.spec_from_file_location(
+            f"gt4py.__compiled_programs__.{self.src_dir.name}._loader", loader_path
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.load(self.src_dir)
 
 
 def _unique_libs(*args: interface.LibraryDependency) -> tuple[interface.LibraryDependency, ...]:

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -12,6 +12,7 @@ import dataclasses
 import json
 import os
 import pathlib
+import textwrap
 import warnings
 from collections.abc import Callable, MutableSequence, Sequence
 from typing import Any
@@ -24,10 +25,11 @@ from gt4py._core import definitions as core_defs, locking
 from gt4py.next import common, config
 from gt4py.next.otf import code_specs, definitions, stages, workflow
 from gt4py.next.otf.compilation import cache as gtx_cache
-from gt4py.next.program_processors.runners.dace.workflow import (
-    common as gtx_wfdcommon,
-    decoration as gtx_wfddecoration,
-)
+from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
+
+
+_SDFG_FILENAME = "sdfg.json"
+_BINDING_FILENAME = "binding.py"
 
 
 def _add_tx_markers(sdfg: dace.SDFG) -> None:
@@ -135,46 +137,50 @@ class CompiledDaceProgram:
         assert result is None
 
 
-@dataclasses.dataclass(frozen=True)
-class DaCeCompilationArtifact:
-    """Result of a DaCe compilation: build folder + library path + SDFG bindings + the SDFG itself.
+def _render_dace_loader(
+    library_relpath: pathlib.Path, bind_func_name: str, device_type: core_defs.DeviceType
+) -> str:
+    return textwrap.dedent(f"""\
+        import json
+        import dace
+        import dace.codegen.compiler as dace_compiler
+        from gt4py._core import definitions as core_defs
+        from gt4py.next.program_processors.runners.dace.workflow import (
+            compilation as gtx_wfdcompilation,
+            decoration as gtx_wfddecoration,
+        )
 
-    The SDFG is carried inline as JSON because dace's load path
-    (``get_program_handle``) needs an SDFG instance to wrap into the
-    returned ``CompiledSDFG``, and the build folder may not contain a
-    ``program.sdfg(z)`` dump under the upcoming minimal-build-dir mode.
-    """
 
-    build_folder: pathlib.Path
-    library_path: pathlib.Path
-    sdfg_json: str
-    binding_source_code: str
-    bind_func_name: str
-    device_type: core_defs.DeviceType
-
-    def load(self) -> stages.ExecutableProgram:
-        # TODO(phimuell): Drop ``sdfg_json`` from the artifact once dace
-        #   exposes a load path that doesn't require an SDFG instance to wrap
-        #   into the returned ``CompiledSDFG``.
-        sdfg = dace.SDFG.from_json(json.loads(self.sdfg_json))
-        sdfg_program = dace_compiler.get_program_handle(self.library_path, sdfg)
-        program = CompiledDaceProgram(sdfg_program, self.bind_func_name, self.binding_source_code)
-        return gtx_wfddecoration.convert_args(program, device=self.device_type)
+        def load(src_dir):
+            sdfg = dace.SDFG.from_json(
+                json.loads((src_dir / {_SDFG_FILENAME!r}).read_text())
+            )
+            sdfg_program = dace_compiler.get_program_handle(
+                src_dir / {str(library_relpath)!r}, sdfg
+            )
+            binding_source = (src_dir / {_BINDING_FILENAME!r}).read_text()
+            program = gtx_wfdcompilation.CompiledDaceProgram(
+                sdfg_program, {bind_func_name!r}, binding_source
+            )
+            return gtx_wfddecoration.convert_args(
+                program, device=core_defs.DeviceType.{device_type.name}
+            )
+        """)
 
 
 @dataclasses.dataclass(frozen=True)
 class DaCeCompiler(
     workflow.ChainableWorkflowMixin[
         stages.CompilableProject[code_specs.SDFGCodeSpec, code_specs.PythonCodeSpec],
-        DaCeCompilationArtifact,
+        stages.CompilationArtifact,
     ],
     workflow.ReplaceEnabledWorkflowMixin[
         stages.CompilableProject[code_specs.SDFGCodeSpec, code_specs.PythonCodeSpec],
-        DaCeCompilationArtifact,
+        stages.CompilationArtifact,
     ],
     definitions.CompilationStep[code_specs.SDFGCodeSpec, code_specs.PythonCodeSpec],
 ):
-    """Run the DaCe build system and produce an on-disk ``DaCeCompilationArtifact``."""
+    """Run the DaCe build system and write a self-contained loader file next to the .so."""
 
     bind_func_name: str
     cache_lifetime: config.BuildCacheLifetime
@@ -189,13 +195,13 @@ class DaCeCompiler(
     def __call__(
         self,
         inp: stages.CompilableProject[code_specs.SDFGCodeSpec, code_specs.PythonCodeSpec],
-    ) -> DaCeCompilationArtifact:
+    ) -> stages.CompilationArtifact:
         with gtx_wfdcommon.dace_context(
             device_type=self.device_type,
             cmake_build_type=self.cmake_build_type,
         ):
-            sdfg_build_folder = gtx_cache.get_cache_folder(inp, self.cache_lifetime)
-            pathlib.Path(sdfg_build_folder).mkdir(parents=True, exist_ok=True)
+            sdfg_build_folder = pathlib.Path(gtx_cache.get_cache_folder(inp, self.cache_lifetime))
+            sdfg_build_folder.mkdir(parents=True, exist_ok=True)
 
             sdfg = dace.SDFG.from_json(inp.program_source.source_code)
 
@@ -203,24 +209,31 @@ class DaCeCompiler(
             if self.add_gpu_trace_markers and self.device_type == core_defs.CUPY_DEVICE_TYPE:
                 _add_tx_markers(sdfg)
 
-            sdfg.build_folder = sdfg_build_folder
+            sdfg.build_folder = str(sdfg_build_folder)
             with locking.lock(sdfg_build_folder):
                 sdfg.compile(validate=False, return_program_handle=False)
-            # ``build_folder_mode`` is set by ``dace_context``; resolve the library
-            # path here so ``get_binary_name`` sees the same mode dace built under.
-            library_path = dace_compiler.get_binary_name(
-                object_folder=sdfg_build_folder, sdfg_name=sdfg.name
-            )
+                # ``build_folder_mode`` is set by ``dace_context``; resolve the library
+                # path inside so ``get_binary_name`` sees the same mode dace built under.
+                library_path = dace_compiler.get_binary_name(
+                    object_folder=sdfg_build_folder, sdfg_name=sdfg.name
+                )
+                assert inp.binding_source is not None
+                sdfg_text = (
+                    inp.program_source.source_code
+                    if isinstance(inp.program_source.source_code, str)
+                    else json.dumps(inp.program_source.source_code)
+                )
+                (sdfg_build_folder / _SDFG_FILENAME).write_text(sdfg_text)
+                (sdfg_build_folder / _BINDING_FILENAME).write_text(inp.binding_source.source_code)
+                (sdfg_build_folder / stages._LOADER_MODULE_FILENAME).write_text(
+                    _render_dace_loader(
+                        library_relpath=library_path.relative_to(sdfg_build_folder),
+                        bind_func_name=self.bind_func_name,
+                        device_type=self.device_type,
+                    )
+                )
 
-        assert inp.binding_source is not None
-        return DaCeCompilationArtifact(
-            build_folder=pathlib.Path(sdfg_build_folder),
-            library_path=library_path,
-            sdfg_json=json.dumps(inp.program_source.source_code),
-            binding_source_code=inp.binding_source.source_code,
-            bind_func_name=self.bind_func_name,
-            device_type=self.device_type,
-        )
+        return stages.CompilationArtifact(src_dir=sdfg_build_folder)
 
 
 class DaCeCompilationStepFactory(factory.Factory):

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -8,6 +8,7 @@
 
 import dataclasses
 import pathlib
+import textwrap
 from typing import Any
 
 import factory
@@ -105,22 +106,24 @@ def extract_connectivity_args(
 
 
 @dataclasses.dataclass(frozen=True)
-class GTFNCompilationArtifact(compiler.CPPCompilationArtifact):
-    def load(self) -> stages.ExecutableProgram:
-        return convert_args(super().load(), device=self.device_type)
-
-
-@dataclasses.dataclass(frozen=True)
 class GTFNCompiler(compiler.CPPCompiler):
-    def _make_artifact(
-        self, src_dir: pathlib.Path, module: pathlib.Path, entry_point_name: str
-    ) -> GTFNCompilationArtifact:
-        return GTFNCompilationArtifact(
-            src_dir=src_dir,
-            module=module,
-            entry_point_name=entry_point_name,
-            device_type=self.device_type,
-        )
+    def _render_loader(self, module: pathlib.Path, entry_point_name: str) -> str:
+        return textwrap.dedent(f"""\
+            from gt4py._core import definitions as core_defs
+            from gt4py.next.otf.compilation import importer
+            from gt4py.next.program_processors.runners.gtfn import convert_args
+
+
+            def load(src_dir):
+                m = importer.import_from_path(
+                    src_dir / {str(module)!r},
+                    sys_modules_prefix="gt4py.__compiled_programs__.",
+                )
+                return convert_args(
+                    getattr(m, {entry_point_name!r}),
+                    device=core_defs.DeviceType.{self.device_type.name},
+                )
+            """)
 
 
 class GTFNCompilerFactory(factory.Factory):

--- a/src/gt4py/next/program_processors/runners/roundtrip.py
+++ b/src/gt4py/next/program_processors/runners/roundtrip.py
@@ -10,10 +10,9 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import importlib.util
-import tempfile
+import hashlib
+import sys
 import textwrap
-import types
 from collections.abc import Iterable
 from typing import Any, Optional
 
@@ -28,7 +27,11 @@ from gt4py.next import (
 from gt4py.next.ffront import foast_to_gtir, foast_to_past, past_to_itir
 from gt4py.next.iterator import ir as itir, transforms as itir_transforms
 from gt4py.next.otf import definitions, stages, workflow
+from gt4py.next.otf.compilation import cache as gtx_cache
 from gt4py.next.type_system import type_info, type_specifications as ts
+
+
+_PROGRAM_FILENAME = "program.py"
 
 
 def _create_tmp(axes: str, origin: str, shape: str, dtype: ts.TypeSpec) -> str:
@@ -109,12 +112,6 @@ def ${id}(${','.join(params)}):
         return f"{node.id} = {_create_tmp(axes, origin, shape, node.dtype)}"
 
 
-# Caches the generated source by IR hash so re-codegen is skipped within a process.
-_SOURCE_CACHE: dict[int, tuple[str, str]] = {}
-# Caches the loaded module by source string so re-exec is skipped within a process.
-_MODULE_CACHE: dict[str, types.ModuleType] = {}
-
-
 def _generate_source(
     ir: itir.Program,
     debug: bool,
@@ -123,28 +120,8 @@ def _generate_source(
     transforms: itir_transforms.GTIRTransform,
 ) -> tuple[str, str]:
     """Generate the Python source for an ITIR program. Returns ``(source_code, entry_point_name)``."""
-    # TODO(tehrengruber): just a temporary solution until we have a proper generic
-    #  caching mechanism
-    cache_key = hash(
-        (
-            ir,
-            transforms,
-            debug,
-            use_embedded,
-            tuple(common.offset_provider_to_type(offset_provider).items()),
-        )
-    )
-    if cache_key in _SOURCE_CACHE:
-        if debug:
-            print(f"Using cached source for key {cache_key}")
-        return _SOURCE_CACHE[cache_key]
-
     ir = transforms(ir, offset_provider=offset_provider)
-
     program = EmbeddedDSL.apply(ir)
-
-    # format output in debug mode for better debuggability
-    # (e.g. line numbers, overview in the debugger).
     if debug:
         program = codegen.format_python_source(program)
 
@@ -181,86 +158,86 @@ def _generate_source(
     source_code = f"{header}{offset_literals_src}\n{axis_literals_src}\n{program}"
 
     assert isinstance(ir, itir.Program)
-    entry_point_name = ir.id
-
-    _SOURCE_CACHE[cache_key] = (source_code, entry_point_name)
-    return source_code, entry_point_name
+    return source_code, str(ir.id)
 
 
-def _load_module(source_code: str, debug: bool) -> types.ModuleType:
-    if source_code in _MODULE_CACHE:
-        return _MODULE_CACHE[source_code]
-
-    if debug:
-        # Write to a real .py so debuggers/tracebacks have file/line info.
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", encoding="utf-8", delete=False
-        ) as source_file:
-            source_file.write(source_code)
-            source_file_name = source_file.name
-        print(source_file_name)
-        spec = importlib.util.spec_from_file_location("module.name", source_file_name)
-        mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
-        spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    else:
-        mod = types.ModuleType("roundtrip_module")
-        exec(compile(source_code, "<roundtrip>", "exec"), mod.__dict__)
-
-    _MODULE_CACHE[source_code] = mod
-    return mod
+def _find_module_qualname(obj: Any) -> tuple[str, str] | None:
+    """Find ``(module, attr)`` such that ``getattr(sys.modules[module], attr) is obj``."""
+    for mod_name, mod in list(sys.modules.items()):
+        if mod is None or not hasattr(mod, "__dict__"):
+            continue
+        for attr_name, value in vars(mod).items():
+            if value is obj:
+                return mod_name, attr_name
+    return None
 
 
-@dataclasses.dataclass(frozen=True)
-class RoundtripArtifact:
-    """Source-string artifact for the roundtrip backend.
+def _dispatch_backend_import_stmt(backend: next_backend.Backend | None) -> str:
+    if backend is None:
+        return "_dispatch_backend = None"
+    qualname = _find_module_qualname(backend)
+    if qualname is None:
+        raise NotImplementedError(
+            "Roundtrip with a non-module-global ``dispatch_backend`` is not supported "
+            "by the loader-file artifact (it cannot be reconstructed by name)."
+        )
+    module, attr = qualname
+    return f"from {module} import {attr} as _dispatch_backend"
 
-    The generated Python source is the artifact: picklable, re-execed on
-    ``load``. When ``debug`` is true, ``load`` writes a temporary ``.py``
-    so debuggers/tracebacks resolve to source lines.
-    """
 
-    source_code: str
-    entry_point_name: str
-    column_axis: common.Dimension | None
-    dispatch_backend: next_backend.Backend | None
-    debug: bool
+def _column_axis_repr(column_axis: common.Dimension | None) -> str:
+    if column_axis is None:
+        return "None"
+    return (
+        f"gtx_common.Dimension({column_axis.value!r}, "
+        f"kind=gtx_common.DimensionKind({column_axis.kind.value!r}))"
+    )
 
-    def load(self) -> stages.ExecutableProgram:
-        mod = _load_module(self.source_code, self.debug)
-        fencil = getattr(mod, self.entry_point_name)
-        captured_column_axis = self.column_axis
-        dispatch_backend = self.dispatch_backend
 
-        def decorated_fencil(
-            *args: Any,
-            offset_provider: dict[str, common.Connectivity | common.Dimension],
-            out: Any = None,
-            column_axis: Optional[
-                common.Dimension
-            ] = None,  # TODO(tehrengruber): unused, kept for signature compat
-            **kwargs: Any,
-        ) -> None:
-            if out is not None:
-                args = (*args, out)
-            fencil(
-                *args,
-                offset_provider=offset_provider,
-                backend=dispatch_backend,
-                column_axis=captured_column_axis,
-                **kwargs,
+def _render_loader(
+    entry_point_name: str, column_axis_repr: str, dispatch_backend_import: str
+) -> str:
+    return textwrap.dedent(f"""\
+        import importlib.util
+        from gt4py.next import common as gtx_common
+
+        {dispatch_backend_import}
+
+
+        def load(src_dir):
+            spec = importlib.util.spec_from_file_location(
+                f"gt4py.__compiled_programs__.{{src_dir.name}}._roundtrip",
+                src_dir / {_PROGRAM_FILENAME!r},
             )
+            assert spec is not None and spec.loader is not None
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            fencil = getattr(mod, {entry_point_name!r})
+            captured_column_axis = {column_axis_repr}
 
-        return decorated_fencil
+            def decorated_fencil(*args, offset_provider, out=None, column_axis=None, **kwargs):
+                if out is not None:
+                    args = (*args, out)
+                fencil(
+                    *args,
+                    offset_provider=offset_provider,
+                    backend=_dispatch_backend,
+                    column_axis=captured_column_axis,
+                    **kwargs,
+                )
+
+            return decorated_fencil
+        """)
 
 
 @dataclasses.dataclass(frozen=True)
-class Roundtrip(workflow.Workflow[definitions.CompilableProgramDef, RoundtripArtifact]):
+class Roundtrip(workflow.Workflow[definitions.CompilableProgramDef, stages.CompilationArtifact]):
     debug: Optional[bool] = None
     use_embedded: bool = True
     dispatch_backend: Optional[next_backend.Backend] = None
     transforms: itir_transforms.GTIRTransform = itir_transforms.apply_common_transforms  # type: ignore[assignment] # TODO(havogt): cleanup interface of `apply_common_transforms`
 
-    def __call__(self, inp: definitions.CompilableProgramDef) -> RoundtripArtifact:
+    def __call__(self, inp: definitions.CompilableProgramDef) -> stages.CompilationArtifact:
         debug = config.DEBUG if self.debug is None else self.debug
 
         source_code, entry_point_name = _generate_source(
@@ -271,13 +248,28 @@ class Roundtrip(workflow.Workflow[definitions.CompilableProgramDef, RoundtripArt
             transforms=self.transforms,
         )
 
-        return RoundtripArtifact(
-            source_code=source_code,
-            entry_point_name=entry_point_name,
-            column_axis=inp.args.column_axis,
-            dispatch_backend=self.dispatch_backend,
-            debug=debug,
+        column_axis_repr = _column_axis_repr(inp.args.column_axis)
+        dispatch_backend_import = _dispatch_backend_import_stmt(self.dispatch_backend)
+        digest = hashlib.sha256(
+            "\0".join(
+                (source_code, entry_point_name, column_axis_repr, dispatch_backend_import)
+            ).encode()
+        ).hexdigest()
+        src_dir = (
+            gtx_cache.get_cache_base_path(config.BUILD_CACHE_LIFETIME)
+            / f"roundtrip_{entry_point_name}_{digest}"
         )
+        src_dir.mkdir(parents=True, exist_ok=True)
+        (src_dir / _PROGRAM_FILENAME).write_text(source_code)
+        (src_dir / stages._LOADER_MODULE_FILENAME).write_text(
+            _render_loader(
+                entry_point_name=entry_point_name,
+                column_axis_repr=column_axis_repr,
+                dispatch_backend_import=dispatch_backend_import,
+            )
+        )
+
+        return stages.CompilationArtifact(src_dir=src_dir)
 
 
 # TODO(tehrengruber): introduce factory

--- a/src/gt4py/next/program_processors/runners/roundtrip.py
+++ b/src/gt4py/next/program_processors/runners/roundtrip.py
@@ -173,13 +173,26 @@ def _find_module_qualname(obj: Any) -> tuple[str, str] | None:
 
 
 def _dispatch_backend_import_stmt(backend: next_backend.Backend | None) -> str:
+    # The loader file has to reconstruct ``dispatch_backend`` at load time without
+    # the in-memory object being available. We do that by writing an ``import``
+    # statement into the generated source, which only works if the Backend
+    # instance is reachable via ``sys.modules`` (i.e. is a module-global). A
+    # Backend created ad-hoc via ``GTFNBackendFactory(...)`` or
+    # ``make_dace_backend(...)`` and held only in a local/fixture scope is not
+    # findable; this is an accepted limitation because Roundtrip is a
+    # development/debugging backend, not a production target. See the
+    # ``Roundtrip.dispatch_backend`` field for the user-facing contract.
     if backend is None:
         return "_dispatch_backend = None"
     qualname = _find_module_qualname(backend)
     if qualname is None:
         raise NotImplementedError(
-            "Roundtrip with a non-module-global ``dispatch_backend`` is not supported "
-            "by the loader-file artifact (it cannot be reconstructed by name)."
+            "Roundtrip's ``dispatch_backend`` must be reachable as a module-level "
+            "attribute (so it can be re-imported by the generated loader). "
+            "Factory-constructed backends that are only bound to a local variable "
+            "or fixture cannot be serialized into the compilation artifact. Either "
+            "assign the backend to a module global, or use a Roundtrip variant "
+            "with ``dispatch_backend=None``/``embedded.run_roundtrip_executor``."
         )
     module, attr = qualname
     return f"from {module} import {attr} as _dispatch_backend"
@@ -232,6 +245,20 @@ def _render_loader(
 
 @dataclasses.dataclass(frozen=True)
 class Roundtrip(workflow.Workflow[definitions.CompilableProgramDef, stages.CompilationArtifact]):
+    """Generate-and-exec Python ``Workflow``.
+
+    .. note::
+       ``dispatch_backend`` must be reachable as a module-level attribute: the
+       generated loader file re-imports it by ``module.attribute`` qualname. A
+       ``Backend`` constructed ad-hoc (e.g. via ``GTFNBackendFactory(...)`` or
+       ``make_dace_backend(...)``) and held only in a local variable or pytest
+       fixture is *not* supported and will raise ``NotImplementedError`` at
+       compile time. Either assign it to a module global, or use one of the
+       module-level Roundtrip backends in this file. Roundtrip is a development
+       backend, so we accept this constraint rather than carry a more elaborate
+       Backend-serialization mechanism.
+    """
+
     debug: Optional[bool] = None
     use_embedded: bool = True
     dispatch_backend: Optional[next_backend.Backend] = None

--- a/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_compiler.py
+++ b/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_compiler.py
@@ -6,21 +6,23 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Minimal contract tests for ``CPPCompilationArtifact``."""
+"""Minimal contract tests for ``stages.CompilationArtifact``."""
 
 import pathlib
 import pickle
 
-from gt4py._core import definitions as core_defs
-from gt4py.next.otf.compilation import compiler
+from gt4py.next.otf import stages
 
 
-def test_cpp_compilation_artifact_pickle_round_trip(tmp_path: pathlib.Path):
-    artifact = compiler.CPPCompilationArtifact(
-        src_dir=tmp_path,
-        module=pathlib.Path("entry.so"),
-        entry_point_name="entry",
-        device_type=core_defs.DeviceType.CPU,
-    )
+def test_compilation_artifact_pickle_round_trip(tmp_path: pathlib.Path):
+    artifact = stages.CompilationArtifact(src_dir=tmp_path)
     restored = pickle.loads(pickle.dumps(artifact))
     assert restored == artifact
+
+
+def test_compilation_artifact_load_execs_loader_file(tmp_path: pathlib.Path):
+    (tmp_path / stages._LOADER_MODULE_FILENAME).write_text(
+        "def load(src_dir):\n    return ('loaded', src_dir)\n"
+    )
+    artifact = stages.CompilationArtifact(src_dir=tmp_path)
+    assert artifact.load() == ("loaded", tmp_path)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -6,15 +6,9 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for the compilation stage of the dace backend workflow.
-
-Covers the GPU TX-marker instrumentation and the picklability of
-``DaCeCompilationArtifact``.
-"""
+"""Tests for the GPU TX-marker instrumentation in the dace backend workflow."""
 
 import contextlib
-import pathlib
-import pickle
 import unittest.mock as mock
 
 import pytest
@@ -82,6 +76,7 @@ def _run_compiler(
     """
     inp = mock.MagicMock()
     inp.program_source.source_code = _make_sdfg_with_gpu_map().to_json()
+    inp.binding_source.source_code = "def bind(*a, **k): ..."
 
     compiler = dace_wf_compilation.DaCeCompiler(
         bind_func_name="bind",
@@ -152,18 +147,3 @@ def test_compiler_skips_tx_markers_for_non_gpu_device(tmp_path):
 
     spy.assert_not_called()
     assert compiled_sdfg.instrument == _NONE
-
-
-def test_dace_compilation_artifact_pickle_round_trip(tmp_path: pathlib.Path):
-    artifact = dace_wf_compilation.DaCeCompilationArtifact(
-        build_folder=tmp_path,
-        library_path=tmp_path / "build" / "libprogram.so",
-        sdfg_json="{}",
-        binding_source_code="def update_sdfg_args(*a, **k): ...",
-        bind_func_name="update_sdfg_args",
-        device_type=core_defs.DeviceType.CPU,
-    )
-
-    restored = pickle.loads(pickle.dumps(artifact))
-
-    assert restored == artifact


### PR DESCRIPTION
**Prototype, stacked on PR https://github.com/GridTools/gt4py/pull/2587** — explores the design discussed in https://github.com/GridTools/gt4py/pull/2587#discussion_r3476044393. Not for merge as-is; opened for review of the shape.

## Idea

Replace the per-backend ``CompilationArtifact`` subclasses (``CPPCompilationArtifact``, ``GTFNCompilationArtifact``, ``DaCeCompilationArtifact``, ``RoundtripArtifact``) with a single concrete dataclass holding only ``src_dir: pathlib.Path``. Each backend's compiler writes a ``_gt4py_load.py`` into the build folder at compile time; ``CompilationArtifact.load()`` execs that file and delegates.

The per-backend artifact subclasses go away. The Protocol goes away. ``Backend.executor`` returns the same concrete dataclass regardless of backend.

## What the loader file looks like

GTFN:

```python
from gt4py._core import definitions as core_defs
from gt4py.next.otf.compilation import importer
from gt4py.next.program_processors.runners.gtfn import convert_args

def load(src_dir):
    m = importer.import_from_path(
        src_dir / 'build/bin/run.cpython-310-x86_64-linux-gnu.so',
        sys_modules_prefix="gt4py.__compiled_programs__.",
    )
    return convert_args(getattr(m, 'run'), device=core_defs.DeviceType.CPU)
```

DaCe: similar, plus ``sdfg.json`` and ``binding.py`` sidecars next to it.

Roundtrip: writes the generated source as ``program.py`` and a loader that re-execs it.

## Pros

- One ``CompilationArtifact`` class. No Protocol, no per-backend subclasses, no ``_make_artifact`` template-method hook.
- Trivially picklable artifact (~50 bytes — just a Path).
- Each build folder is self-describing: ``cat _gt4py_load.py`` shows you how to load it.
- Generalizes cleanly when a new backend appears — just write your loader file.
- Matches the layered-architecture direction tehrengruber pointed at.

## Cons

- **Code-as-data + ``exec()``** at load time. We exec a ``.py`` generated by the compiler.
- **Baked import paths fragility**: the loader does ``from gt4py.next.program_processors.runners.gtfn import convert_args``. If gt4py renames that, **every persistent build cache** built before the rename breaks at load time. Today the load code is in current gt4py, so renames are invisible to existing caches. This shifts the contract: ``BUILD_CACHE_VERSION_ID`` invalidation has to cover any rename in the load path.
- **Roundtrip ``dispatch_backend``** only works for module-attribute-reachable backends (discovered via a ``sys.modules`` scan). ``double_roundtrip`` survives because ``roundtrip.default`` is reachable; ad-hoc factory-constructed ``Backend``s passed as ``dispatch_backend`` raise ``NotImplementedError``. Same constraint as serializing-a-module-global; documented limitation.
- **Generated code = code to maintain**. Each backend now has a template (f-string here) producing the loader file. Bug in the template = bug in every artifact that backend builds, undetected until load.
- **Static analysis** can't follow the generated file. Renaming ``convert_args`` won't get flagged.
- ~~``_SOURCE_CACHE`` / ``_MODULE_CACHE`` in roundtrip~~ gone — replaced by the on-disk cache (same hash-keyed deduplication).

## Verification

- ``run_gtfn`` smoke ✅
- ``run_dace_cpu`` smoke ✅
- ``run_roundtrip`` smoke ✅
- ``double_roundtrip`` smoke ✅ (qualname auto-discovery works)
- bare ``compiler.CPPCompiler`` via ``test_nanobind_build.py`` ✅
- Full sweep (`tests/next_tests/unit_tests/otf_tests/` + `program_processor_tests/runners_tests/` + `feature_tests/otf_tests/`): **446 passed**. Failing: 2 + 2 errors are pre-existing GPU-mode dace_fastcall tests (no GPU on this box) and one flaky dace transformation test that passes in isolation.

## Files touched

- ``src/gt4py/next/otf/stages.py``: replace Protocol with concrete ``CompilationArtifact``.
- ``src/gt4py/next/otf/compilation/compiler.py``: drop ``CPPCompilationArtifact``; ``CPPCompiler.__call__`` writes loader file.
- ``src/gt4py/next/program_processors/runners/gtfn.py``: drop ``GTFNCompilationArtifact``; ``GTFNCompiler`` overrides ``_render_loader``.
- ``src/gt4py/next/program_processors/runners/dace/workflow/compilation.py``: drop ``DaCeCompilationArtifact``; ``DaCeCompiler`` writes ``sdfg.json`` + ``binding.py`` + loader.
- ``src/gt4py/next/program_processors/runners/roundtrip.py``: drop ``RoundtripArtifact``, ``_SOURCE_CACHE``, ``_MODULE_CACHE``; ``Roundtrip`` writes ``program.py`` + loader under a hash-keyed session-cache folder; ``dispatch_backend`` reconstructed via ``sys.modules`` scan.
- Tests: shrink ``test_compiler.py`` to one pickle + one ``load()``-via-exec test for the unified artifact; drop per-backend pickle tests.

Net: **+234 / −262** across 7 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)