### PR TITLE
refactor[next]: derive type-system traversal from datamodel introspection

### DIFF
--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -14,7 +14,7 @@ from typing import Any, Final, Literal, Sequence, Type, TypeGuard, TypeVar, cast
 import numpy as np
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping, utils
+from gt4py.eve import datamodels as eve_datamodels, extended_typing as xtyping, utils
 from gt4py.next import common, utils as next_utils
 from gt4py.next.iterator.type_system import type_specifications as it_ts
 from gt4py.next.type_system import type_specifications as ts
@@ -66,42 +66,72 @@ def _function_type_arg_groups(
     )
 
 
-def _function_type_children(function_type: ts.FunctionType) -> tuple[ts.TypeSpec, ...]:
-    """Return the argument and return sub-types of a function type, in canonical order."""
-    return tuple(child for group in _function_type_arg_groups(function_type) for child in group)
+_TypeSpecT = TypeVar("_TypeSpecT", bound=ts.TypeSpec)
 
 
-def _map_function_type(
-    function_type: ts.FunctionType, transform: Callable[[ts.TypeSpec], ts.TypeSpec]
-) -> ts.FunctionType:
-    """Apply ``transform`` to each argument and return sub-type of a function type."""
-    return ts.FunctionType(
-        pos_only_args=[transform(a) for a in function_type.pos_only_args],
-        pos_or_kw_args={name: transform(a) for name, a in function_type.pos_or_kw_args.items()},
-        kw_only_args={name: transform(a) for name, a in function_type.kw_only_args.items()},
-        returns=transform(function_type.returns),
-    )
-
-
-def _type_params(symbol_type: ts.TypeSpec) -> tuple[ts.TypeSpec, ...]:
-    """Return the immediate type-parameter sub-types of ``symbol_type``.
-
-    These are its dtype, element type, tuple elements, or function argument / return types.
+def _map_field_value(value: Any, transform: Callable[[ts.TypeSpec], ts.TypeSpec]) -> Any:
     """
-    match symbol_type:
-        case ts.FieldType(dtype=dtype):
-            return (dtype,)
-        case ts.ListType(element_type=element_type):
-            return (element_type,)
-        case ts.TupleType(types=types) | ts.NamedCollectionType(types=types):
-            return tuple(types)
-        case ts.FunctionType():
-            return _function_type_children(symbol_type)
-    # callable type wrappers (e.g. the field operator types in `ffront`) carry their
-    # signature in a `definition` attribute
-    if isinstance(definition := getattr(symbol_type, "definition", None), ts.TypeSpec):
-        return (definition,)
-    return ()
+    Apply ``transform`` to the `TypeSpec` instances inside a datamodel field value.
+
+    Preserves the container structure and the identity of the value if nothing changes.
+    """
+    if isinstance(value, ts.TypeSpec):
+        return transform(value)
+    if isinstance(value, (list, tuple)):
+        new_items = [transform(v) if isinstance(v, ts.TypeSpec) else v for v in value]
+        if all(new is old for new, old in zip(new_items, value)):
+            return value
+        return type(value)(new_items)
+    if isinstance(value, dict):
+        new_values = {
+            k: transform(v) if isinstance(v, ts.TypeSpec) else v for k, v in value.items()
+        }
+        if all(new is old for new, old in zip(new_values.values(), value.values())):
+            return value
+        return new_values
+    return value
+
+
+def iter_type_children(symbol_type: ts.TypeSpec) -> Iterator[ts.TypeSpec]:
+    """
+    Iterate over the immediate `TypeSpec` children of ``symbol_type``, in field order.
+
+    The children are derived generically from the datamodel fields of the type: every field
+    value that is a `TypeSpec`, or a list / tuple / dict containing `TypeSpec` values, is a
+    child. E.g. the dtype of a `FieldType`, the element types of the collection types, the
+    argument and return types of a `FunctionType`, and the signature (``definition``) of the
+    callable wrapper types (field operators etc.) -- including `TypeSpec` subclasses defined
+    outside this module, without requiring registration here.
+    """
+    for name in type(symbol_type).__datamodel_fields__.keys():
+        value = getattr(symbol_type, name)
+        if isinstance(value, ts.TypeSpec):
+            yield value
+        elif isinstance(value, (list, tuple)):
+            yield from (v for v in value if isinstance(v, ts.TypeSpec))
+        elif isinstance(value, dict):
+            yield from (v for v in value.values() if isinstance(v, ts.TypeSpec))
+
+
+def map_type_children(
+    symbol_type: _TypeSpecT, transform: Callable[[ts.TypeSpec], ts.TypeSpec]
+) -> _TypeSpecT:
+    """
+    Reconstruct ``symbol_type`` with ``transform`` applied to each immediate `TypeSpec` child.
+
+    The children are the same as in :func:`iter_type_children`; all other fields are kept
+    unchanged. If no child changes (by identity), ``symbol_type`` itself is returned.
+    Together with :func:`iter_type_children` this forms the generic one-level traversal API
+    on which recursive algorithms over the type system are built (`is_generic`,
+    `substitute_type_vars`, ...).
+    """
+    changes: dict[str, Any] = {}
+    for name in type(symbol_type).__datamodel_fields__.keys():
+        value = getattr(symbol_type, name)
+        new_value = _map_field_value(value, transform)
+        if new_value is not value:
+            changes[name] = new_value
+    return eve_datamodels.evolve(symbol_type, **changes) if changes else symbol_type
 
 
 def is_generic(symbol_type: ts.TypeSpec) -> bool:
@@ -129,7 +159,7 @@ def is_generic(symbol_type: ts.TypeSpec) -> bool:
     """
     if isinstance(symbol_type, (ts.DeferredType, ts.TypeVarType)):
         return True
-    return any(is_generic(p) for p in _type_params(symbol_type))
+    return any(is_generic(child) for child in iter_type_children(symbol_type))
 
 
 def type_class(symbol_type: ts.TypeSpec) -> Type[ts.TypeSpec]:
@@ -723,6 +753,7 @@ def substitute_type_vars(
     Replace all type variables in ``type_`` that are bound in ``binding``.
 
     Unbound type variables and all other generic parts (e.g. `DeferredType`) are kept as-is.
+    Fully concrete (sub-)types are returned unchanged (by identity).
 
     Examples:
         >>> var = ts.TypeVarType(name="T", constraints=(ts.ScalarType(kind=ts.ScalarKind.FLOAT64),))
@@ -738,25 +769,12 @@ def substitute_type_vars(
     if not binding:
         return type_
 
-    def substitute_leaf(leaf: ts.TypeSpec) -> ts.TypeSpec:
-        # `tree_map_type` has already mapped the tuple structure; what is left is to substitute
-        # inside the primitive constituents, i.e. in their dtype / element type / signature.
-        match leaf:
-            case ts.TypeVarType():
-                return binding.get(leaf.name, leaf)
-            case ts.FieldType(dims=dims, dtype=dtype):
-                new_dtype = substitute_type_vars(dtype, binding)
-                assert isinstance(new_dtype, (ts.ScalarType, ts.ListType, ts.TypeVarType))
-                return ts.FieldType(dims=dims, dtype=new_dtype)
-            case ts.ListType(element_type=element_type, offset_type=offset_type):
-                new_element_type = substitute_type_vars(element_type, binding)
-                assert isinstance(new_element_type, ts.DataType)
-                return ts.ListType(element_type=new_element_type, offset_type=offset_type)
-            case ts.FunctionType():
-                return _map_function_type(leaf, lambda a: substitute_type_vars(a, binding))
-        return leaf
+    def substitute(current: ts.TypeSpec) -> ts.TypeSpec:
+        if isinstance(current, ts.TypeVarType):
+            return binding.get(current.name, current)
+        return map_type_children(current, substitute)
 
-    return tree_map_type(substitute_leaf)(type_)
+    return substitute(type_)
 
 
 def promote(

--- a/tests/next_tests/unit_tests/type_system_tests/test_type_info.py
+++ b/tests/next_tests/unit_tests/type_system_tests/test_type_info.py
@@ -10,13 +10,11 @@ from typing import Optional
 
 import pytest
 
-from gt4py.next import (
-    Dimension,
-    DimensionKind,
-)
-from gt4py.next.type_system import type_info, type_specifications as ts
+from gt4py.next import Dimension, DimensionKind
 from gt4py.next.ffront import type_specifications as ts_ffront
 from gt4py.next.iterator.type_system import type_specifications as ts_it
+from gt4py.next.type_system import type_info, type_specifications as ts
+
 
 TDim = Dimension("TDim")  # Meaningless dimension, used for tests.
 
@@ -558,7 +556,26 @@ class TestSubstituteTypeVars:
 
     def test_concrete_is_returned_unchanged(self):
         concrete = ts.FieldType(dims=[TDim], dtype=float64_type)
-        assert type_info.substitute_type_vars(concrete, {"T": float32_type}) == concrete
+        assert type_info.substitute_type_vars(concrete, {"T": float32_type}) is concrete
+
+    def test_substitute_operator_wrapper_type(self):
+        # wrapper types (e.g. `FieldOperatorType`) carry their signature in a `definition`
+        # field; the generic traversal substitutes through them without special-casing
+        fieldop_type = ts_ffront.FieldOperatorType(
+            definition=ts.FunctionType(
+                pos_only_args=[ts.FieldType(dims=[TDim], dtype=float_var)],
+                pos_or_kw_args={},
+                kw_only_args={},
+                returns=ts.FieldType(dims=[TDim], dtype=float_var),
+            )
+        )
+        substituted = type_info.substitute_type_vars(fieldop_type, {"T": float32_type})
+        assert isinstance(substituted, ts_ffront.FieldOperatorType)
+        assert substituted.definition.pos_only_args[0] == ts.FieldType(
+            dims=[TDim], dtype=float32_type
+        )
+        assert substituted.definition.returns == ts.FieldType(dims=[TDim], dtype=float32_type)
+        assert not type_info.is_generic(substituted)
 
     def test_substitute_function_type(self):
         func_type = ts.FunctionType(


### PR DESCRIPTION
## Description

Stacked on `dtype-generics-2-type-system` (GridTools/gt4py#2660): replaces the ad-hoc per-class recursion helpers in `type_info.py` with a single generic one-level traversal API derived from datamodel field introspection.

**Motivation.** The base branch contains two hand-rolled recursions over the type system that disagree with each other: `is_generic` recurses via `_type_params` (a central `match` plus a `getattr(symbol_type, "definition", None)` duck-typing hack to reach the ffront wrapper types it cannot import), while `substitute_type_vars` recurses differently (`tree_map_type` for tuple structure plus a manual `match` over `FieldType`/`ListType`/`FunctionType`) and does *not* descend into `definition` wrappers. The asymmetry surfaces downstream: `SpecializeTypeVars._substitute` on `dtype-generics-3-field-operators` must special-case `FieldOperatorType`/`ScanOperatorType` by hand.

**Changes.** Since `TypeSpec`s are frozen eve datamodels, the children of a type can be derived from field introspection instead of being enumerated per class:

- `iter_type_children(t)` — every datamodel field value that is a `TypeSpec` (or a list/tuple/dict containing them) is a child. Covers `FieldType.dtype`, `ListType.element_type`, collection element types, all `FunctionType` argument groups plus `returns`, and `TypeSpec` subclasses defined outside the module (`FieldOperatorType`, `ScanOperatorType`, `IteratorType`, …) with no registration and no `definition` duck-typing.
- `map_type_children(t, f)` — rebuilds via `eve.datamodels.evolve` with `f` applied to each child; returns `t` itself when nothing changed (identity-preserving) and re-runs the datamodel validators on reconstruction (replacing the manual `assert isinstance(...)` guards).

On top of this, `is_generic` and `substitute_type_vars` collapse to a few lines each; `_type_params`, `_function_type_children`, and `_map_function_type` are deleted. Substitution now also works through callable wrapper types, so the special cases in branch 3's `SpecializeTypeVars._substitute` can collapse to a single `substitute_type_vars` call.

**Deliberately not folded in:** `_bind` and `is_compatible_type` keep their explicit recursions — their domain rules (scalar→0-dim-field promotion, tolerant structural mismatch, group-wise arity zipping via the retained `_function_type_arg_groups`) are clearer spelled out; a unification-style merge is worth revisiting when dimension genericity lands. `primitive_constituents`/`tree_map_type` stay separate as they traverse *value* structure (tuple nesting), not type-parameter structure.

**Behavioral note:** `is_generic` now sees children the ad-hoc version ignored (e.g. `IteratorType.element_type`, `it_ts.ProgramType.params`) — more correct, and all current callers pass `FunctionType`s or data types, but it is a semantic widening.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.

https://claude.ai/code/session_01WRpXDDGQe86Gie4s9RZHnP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRpXDDGQe86Gie4s9RZHnP)_