### PR TITLE
fix[next-dace]: do not fingerprint SDFG element guids in the compile cache key

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -462,11 +462,26 @@ class DaCeTranslator(
             # Set 'hash=True' to compute the SDFG hash and store it in the JSON.
             #   We compute the hash in order to refresh `cfg_list` on the SDFG,
             #   which makes the JSON serialization stable.
-            source_code=sdfg.to_json(hash=True),
+            # `guid` is a per-element identity token: it does not affect code generation, and
+            #   `SDFG.from_json()` assigns fresh ids anyway. Keeping it would make the compile
+            #   cache key depend on element creation order, so two structurally identical
+            #   lowerings of the same program would not share a cached build.
+            source_code=_drop_element_ids(sdfg.to_json(hash=True)),
             library_deps=tuple(),
             code_spec=code_specs.SDFGCodeSpec(),
         )
         return module
+
+
+def _drop_element_ids(json_obj: Any) -> Any:
+    """Recursively remove `guid` keys from a serialized SDFG."""
+    if isinstance(json_obj, dict):
+        return {k: _drop_element_ids(v) for k, v in json_obj.items() if k != "guid"}
+    if isinstance(json_obj, list):
+        return [_drop_element_ids(v) for v in json_obj]
+    if isinstance(json_obj, tuple):
+        return tuple(_drop_element_ids(v) for v in json_obj)
+    return json_obj
 
 
 class DaCeTranslationStepFactory(factory.Factory):


### PR DESCRIPTION
## Problem

The dace compile cache folder is named after a fingerprint of the `ProgramSource`, whose
`source_code` is `sdfg.to_json(hash=True)`. That JSON embeds a per-element `guid`, and guids are
assigned in whatever order SDFG elements happen to be created. Two structurally identical lowerings
of the same program therefore get different cache keys and miss each other's cached build.

This does not hurt a warm rerun — the translation cache is keyed by a deterministic *input*
fingerprint, so the SDFG is loaded rather than re-lowered and the guids come back identical. It
does mean that two independent cold builds — two machines, two CI runners, a rebuilt cache — can
never agree on a compiled-artifact key.

## Why the fingerprint, not the ids

guids never reach the generated code, and `SDFG.from_json()` assigns fresh ids on load, so they are
dead weight in the cached program source. dace's own `SDFG.hash_sdfg()` already excludes `guid`
(along with `hash`, `name`, `cfg_list_id`, ...) when it summarises an SDFG's structure. The
top-level `hash` field is kept here for exactly that reason.

Making dace's `generate_element_id()` deterministic instead would be the wrong lever: it is
unnecessary (see below), and a global counter would collide across independently generated SDFGs,
breaking `dace/cli/sdfg_diff.py`, which matches elements across two loaded SDFGs by guid.

## Evidence

icon4py's `vertically_implicit_solver_at_predictor_step` stencil, `dace_cpu`, 5 cold builds with a
fresh build cache each time. dace carries only iteration-order fixes; `generate_element_id()` is
left as `uuid.uuid4()`:

| | distinct over 5 builds |
|---|---|
| raw serialized SDFG | 5 — guids churn, as expected |
| serialized SDFG, `guid` stripped | **1** — structure is identical |
| generated `.cpp` | **1** — byte-identical |
| compile cache key, before this PR | 5 |
| compile cache key, with this PR | **1** |

So the generated code is provably guid-insensitive: the raw SDFG differs in all five builds while
the emitted C++ is byte-identical.

## Depends on

A stable key is only meaningful once the SDFG *structure* is deterministic. That needs the
companion dace fix for set-iteration order in `isolate_nested_sdfg` / `multistate_inline` /
`array_elimination`. Without it this PR makes the key stable-per-structure, not stable-per-program.

## Notes

Related to #2648, which generalised the fingerprint infrastructure with a default-include /
explicit-opt-out policy. If that mechanism is the preferred place to express "ignore `guid`", I am
happy to move the exclusion there rather than stripping the key in `translation.py`.

No test yet — the defect only reproduces across processes. An assertion that two `to_json()` outputs
of structurally equal SDFGs yield the same cache key would cover it; tell me where you would like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
