### PR TITLE
feat[next]: distribute a shift over a concat_where

### DIFF
--- a/src/gt4py/next/iterator/transforms/concat_where/__init__.py
+++ b/src/gt4py/next/iterator/transforms/concat_where/__init__.py
@@ -10,9 +10,15 @@ from gt4py.next.iterator.transforms.concat_where.canonicalize_domain_argument im
     canonicalize_domain_argument,
 )
 from gt4py.next.iterator.transforms.concat_where.expand_tuple_args import expand_tuple_args
+from gt4py.next.iterator.transforms.concat_where.push_shifts import push_shifts
 from gt4py.next.iterator.transforms.concat_where.transform_to_as_fieldop import (
     transform_to_as_fieldop,
 )
 
 
-__all__ = ["canonicalize_domain_argument", "expand_tuple_args", "transform_to_as_fieldop"]
+__all__ = [
+    "canonicalize_domain_argument",
+    "expand_tuple_args",
+    "push_shifts",
+    "transform_to_as_fieldop",
+]

--- a/src/gt4py/next/iterator/transforms/concat_where/push_shifts.py
+++ b/src/gt4py/next/iterator/transforms/concat_where/push_shifts.py
@@ -61,7 +61,10 @@ same scope its value was already written in -- under a name that is fresh in the
 substituted under a binder.
 
 Sinking into a `scan` is not merely unprofitable but wrong -- the fold would run over
-a different range -- so a `scan` stencil declines rather than being wrapped.
+a different range -- so a `scan` stencil declines rather than being wrapped. A binding
+that merely feeds a `scan` declines too, for a different reason: a `scan` argument is
+materialized either way, so there is no barrier left to remove and the copies the
+rewrite pays for buy nothing.
 
 It must run
 
@@ -198,6 +201,40 @@ def _shifted_reads(
 def _is_rebound(body: itir.Expr, param: eve.concepts.SymbolName) -> bool:
     """Whether `body` binds `param` again somewhere, shadowing the outer binding."""
     return any(sym.id == param for sym in body.walk_values().if_isinstance(itir.Sym))
+
+
+def _refers_to_any(expr: itir.Expr, names: set[eve.concepts.SymbolName]) -> bool:
+    return any(ref.id in names for ref in expr.walk_values().if_isinstance(itir.SymRef))
+
+
+def _is_scan(expr: itir.Expr) -> bool:
+    return cpm.is_applied_as_fieldop(expr) and cpm.is_call_to(expr.fun.args[0], "scan")
+
+
+def _feeds_a_scan(body: itir.Expr, param: eve.concepts.SymbolName) -> bool:
+    """Whether a value derived from `param` reaches an argument of a `scan`.
+
+    A `scan` argument is materialized whatever this pass does, so there is no fusion
+    barrier left to remove and the copies the rewrite pays for buy nothing. This is an
+    over approximation on purpose -- it follows every binding and ignores shadowing --
+    because being wrong here costs an optimization, not correctness.
+    """
+    tainted = {param}
+    while True:
+        grown = False
+        for call in body.walk_values().if_isinstance(itir.FunCall):
+            if not cpm.is_let(call):
+                continue
+            for bound, arg in zip(call.fun.params, call.args, strict=True):
+                if bound.id not in tainted and _refers_to_any(arg, tainted):
+                    tainted.add(bound.id)
+                    grown = True
+        if not grown:
+            break
+    return any(
+        _is_scan(call) and any(_refers_to_any(arg, tainted) for arg in call.args)
+        for call in body.walk_values().if_isinstance(itir.FunCall)
+    )
 
 
 def _bound_names(node: itir.Node) -> set[str]:
@@ -353,6 +390,8 @@ class PushShiftIntoConcatWhere(eve.PreserveLocationVisitor, eve.NodeTranslator):
             # Substituting under a binder that shadows `param` would rewrite reads of a
             #  different value; such a body is left alone rather than analyzed.
             if _is_rebound(body, param.id):
+                continue
+            if _feeds_a_scan(body, param.id):
                 continue
             replacements: dict[tuple[common.Dimension, int], itir.Sym] = {}
             for (dim, distance), shift_fun in _shifted_reads(body, param.id).items():

--- a/src/gt4py/next/iterator/transforms/concat_where/push_shifts.py
+++ b/src/gt4py/next/iterator/transforms/concat_where/push_shifts.py
@@ -1,0 +1,414 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Distribute a shift over a `concat_where`.
+
+A shifted read of a `concat_where` result forces that result to be materialized:
+neither the `as_fieldop` fusion of the gtfn pipeline nor the map fusion of the dace
+pipeline can fuse a producer into a consumer that reads it at an offset, and the
+`concat_where` blocks the usual escape of moving the shift onto the producer's own
+inputs. This pass moves it::
+
+    as_fieldop(lambda it: deref(shift(K, d)(it)))(concat_where(u<K: [lo, hi[>, a, b))
+      ->
+    concat_where(u<K: [lo - d, hi - d[>, shift_d(a), shift_d(b))
+
+where `shift_d` distributes the shift down to the leaves::
+
+    shift_d(as_fieldop(S)(x0, ..., xn)) == as_fieldop(S)(shift_d(x0), ..., shift_d(xn))
+
+Translating the condition together with the expression is what makes the rewrite
+safe: the shifted branch is only selected where the original branch was selected at
+the shifted position. This matters because a branch may be readable on a wider index
+range than it is selected on -- reading one element past the end of the selected
+range can be perfectly in bounds and still meaningless.
+
+Sinking to the leaves is essential rather than an optimization. Stopping at
+`as_fieldop(shift)(a)` leaves the shift on the intermediate `a`, which is the very
+fusion barrier this pass exists to remove, and merely moves the materialization.
+
+The pass never guesses. It fires only when the shape is recognized syntactically and
+every leaf the shift would reach can be classified from an already computed `type`;
+anything else declines.
+
+A `let` whose bound value is a `concat_where` read through a shift is handled by
+adding one sibling binding per distinct shift distance rather than by inlining the
+bound value into its use sites::
+
+    let a = cw in ... a[+1] ... a[+1] ... a ...
+      ->
+    let a = cw, a_p1 = concat_where(c', shift_1(t), shift_1(f)) in ... a_p1 ... a ...
+
+so the number of copies of `cw` is the number of distinct offsets it is read at, not
+the number of uses, and the unshifted uses keep sharing the original binding. The
+copies are never folded back together: the dace pipeline
+(`apply_fieldview_transforms`) runs neither `fuse_as_fieldop` nor CSE, so whatever
+this pass duplicates stays duplicated all the way to the backend.
+
+A new binding that is read only once is then inlined at that read, which costs nothing
+and keeps the shifted `concat_where` in the same scope as the expression consuming it.
+
+Substituting a binding by hand risks capturing the free variables of the substituted
+expression. The new binding is therefore placed as a sibling of the original -- the
+same scope its value was already written in -- under a name that is fresh in the whole
+`let`; moving it inward afterwards is left to the project's capture correct
+`inline_lambda`; and a parameter that the body rebinds anywhere is skipped rather than
+substituted under a binder.
+
+Sinking into a `scan` is not merely unprofitable but wrong -- the fold would run over
+a different range -- so a `scan` stencil declines rather than being wrapped.
+
+It must run
+
+* after `concat_where.canonicalize_domain_argument`, so the condition is a plain
+  domain with a single range,
+* before `infer_domain.infer_program`, so the new branch domains are inferred, and
+* before `concat_where.transform_to_as_fieldop`, which replaces the `concat_where`
+  by a position dependent `if_` that a shift can no longer be pushed through.
+
+Translating a condition can leave a branch selected on an empty region. Deciding that
+requires the inferred domain of the `concat_where`, which does not exist yet at this
+position, so it is deliberately left to `prune_empty_concat_where` downstream.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+from typing import Optional
+
+from gt4py import eve
+from gt4py.eve import utils as eve_utils
+from gt4py.next import common
+from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.ir_utils import (
+    common_pattern_matcher as cpm,
+    domain_utils,
+    ir_makers as im,
+    misc as ir_misc,
+)
+from gt4py.next.iterator.transforms import inline_lambdas
+from gt4py.next.type_system import type_info, type_specifications as ts
+
+
+def _shift_dim_and_distance(stencil: itir.Expr) -> Optional[tuple[common.Dimension, int]]:
+    """If `stencil` is `lambda p: deref(shift(K, d)(p))` return `(K, d)`, else `None`."""
+    if not isinstance(stencil, itir.Lambda) or len(stencil.params) != 1:
+        return None
+    body = stencil.expr
+    if not cpm.is_call_to(body, "deref"):
+        return None
+    shifted = body.args[0]
+    if not cpm.is_applied_shift(shifted):
+        return None
+    if not cpm.is_ref_to(shifted.args[0], stencil.params[0].id):
+        return None
+    offsets = shifted.fun.args
+    if len(offsets) != 2:
+        return None
+    off, val = offsets
+    if not isinstance(off, itir.CartesianOffset):
+        return None
+    if off.domain != off.codomain:
+        return None
+    if not (isinstance(val, itir.OffsetLiteral) and isinstance(val.value, int)):
+        return None
+    return ir_misc.dim_from_axis_literal(off.domain), val.value
+
+
+def _translate_bound(bound: itir.Expr, distance: int) -> itir.Expr:
+    if bound in (itir.InfinityLiteral.POSITIVE, itir.InfinityLiteral.NEGATIVE):
+        return bound
+    return im.plus(bound, -distance)
+
+
+def _translate_cond(cond: itir.Expr, shift_dim: common.Dimension, distance: int) -> itir.Expr:
+    """Translate the range of `shift_dim` in `cond` by `-distance`."""
+    sym_domain = domain_utils.SymbolicDomain.from_expr(cond)
+    new_ranges = dict(sym_domain.ranges)
+    rng = new_ranges[shift_dim]
+    new_ranges[shift_dim] = domain_utils.SymbolicRange(
+        _translate_bound(rng.start, distance), _translate_bound(rng.stop, distance)
+    )
+    return domain_utils.SymbolicDomain(sym_domain.grid_type, new_ranges).as_expr()
+
+
+class _DimUse(enum.Enum):
+    """Whether an expression varies along a dimension."""
+
+    WITHOUT = enum.auto()
+    WITH = enum.auto()
+    UNKNOWN = enum.auto()
+
+
+def _dim_use(expr: itir.Expr, dim: common.Dimension) -> _DimUse:
+    """Classifies whether `expr` varies along `dim`.
+
+    Only an available type yields a definite answer. Anything else is `UNKNOWN`,
+    which makes the caller decline: sinking a shift onto an argument that does not
+    have the dimension makes domain inference fail, and not sinking one onto an
+    argument that does have it silently changes the result, so neither direction is
+    safe to guess. Tuples and lists are `UNKNOWN` too, since a shifted tuple or list
+    iterator cannot be dereferenced componentwise here.
+    """
+    if isinstance(expr, itir.Literal):
+        return _DimUse.WITHOUT
+    type_ = expr.type
+    if type_ is None or isinstance(type_, ts.DeferredType):
+        return _DimUse.UNKNOWN
+    if isinstance(type_, ts.TupleType):
+        return _DimUse.UNKNOWN
+    constituents = list(type_info.primitive_constituents(type_))
+    if len(constituents) != 1:
+        return _DimUse.UNKNOWN
+    (constituent,) = constituents
+    if isinstance(constituent, ts.ScalarType):
+        return _DimUse.WITHOUT
+    if not isinstance(constituent, ts.FieldType):
+        return _DimUse.UNKNOWN
+    if isinstance(constituent.dtype, ts.ListType):
+        return _DimUse.UNKNOWN
+    return _DimUse.WITH if dim in constituent.dims else _DimUse.WITHOUT
+
+
+def _shifted_reads(
+    body: itir.Expr, param: eve.concepts.SymbolName
+) -> dict[tuple[common.Dimension, int], itir.Expr]:
+    """Maps each distinct non zero shift `body` applies directly to `param` to its `as_fieldop`.
+
+    Several reads at the same distance share one entry, which is what makes the number
+    of copies this pass creates proportional to the number of distinct offsets.
+    """
+    reads: dict[tuple[common.Dimension, int], itir.Expr] = {}
+    for call in body.walk_values().if_isinstance(itir.FunCall):
+        if not (_is_plain_as_fieldop(call) and len(call.args) == 1):
+            continue
+        assert isinstance(call.fun, itir.FunCall)
+        shift_info = _shift_dim_and_distance(call.fun.args[0])
+        if shift_info is not None and shift_info[1] != 0 and cpm.is_ref_to(call.args[0], param):
+            reads.setdefault(shift_info, call.fun)
+    return reads
+
+
+def _is_rebound(body: itir.Expr, param: eve.concepts.SymbolName) -> bool:
+    """Whether `body` binds `param` again somewhere, shadowing the outer binding."""
+    return any(sym.id == param for sym in body.walk_values().if_isinstance(itir.Sym))
+
+
+def _bound_names(node: itir.Node) -> set[str]:
+    return {str(sym.id) for sym in node.walk_values().if_isinstance(itir.Sym, itir.SymRef)}
+
+
+@dataclasses.dataclass(frozen=True)
+class _ReplaceShiftedReads(eve.PreserveLocationVisitor, eve.NodeTranslator):
+    """Replaces `as_fieldop(shift(K, d))(param)` by a reference to a new binding.
+
+    Sound only because the caller has established that `param` is not rebound in the
+    visited expression, so every occurrence refers to the same binding.
+    """
+
+    param: eve.concepts.SymbolName
+    replacements: dict[tuple[common.Dimension, int], itir.Sym]
+
+    def visit_FunCall(self, node: itir.FunCall) -> itir.Expr:
+        if _is_plain_as_fieldop(node) and len(node.args) == 1:
+            assert isinstance(node.fun, itir.FunCall)
+            shift_info = _shift_dim_and_distance(node.fun.args[0])
+            if (
+                shift_info is not None
+                and cpm.is_ref_to(node.args[0], self.param)
+                and shift_info in self.replacements
+            ):
+                return im.ref(self.replacements[shift_info].id, node.type)
+        return self.generic_visit(node)
+
+
+def _is_plain_as_fieldop(expr: itir.Expr) -> bool:
+    """An `as_fieldop` applied to a stencil alone, i.e. without an explicit domain."""
+    return cpm.is_applied_as_fieldop(expr) and len(expr.fun.args) == 1
+
+
+def _sink_shift(shift_fun: itir.Expr, dim: common.Dimension, arg: itir.Expr) -> Optional[itir.Expr]:
+    """Applies the shift `as_fieldop` `shift_fun` to `arg`, sinking it to the leaves.
+
+    Returns `None` if the shift cannot be sunk soundly, in which case the whole
+    rewrite must be abandoned. Leaving the shift on a compound intermediate counts as
+    a failure rather than a fallback: that is the shape the pass exists to remove,
+    and it measures worse than not rewriting at all.
+    """
+    if cpm.is_applied_as_fieldop(arg):
+        if not _is_plain_as_fieldop(arg):
+            return None  # an explicit domain argument would be left stale
+        if cpm.is_call_to(arg.fun.args[0], "scan"):
+            return None  # sinking would run the fold over a different range
+        new_args = []
+        for a in arg.args:
+            match _dim_use(a, dim):
+                case _DimUse.WITHOUT:
+                    new_args.append(a)
+                case _DimUse.WITH:
+                    if (new_arg := _sink_shift(shift_fun, dim, a)) is None:
+                        return None
+                    new_args.append(new_arg)
+                case _DimUse.UNKNOWN:
+                    return None
+        return itir.FunCall(fun=arg.fun, args=new_args, type=arg.type)
+
+    # Terminal positions: a name, a literal, or a nested `concat_where` that the
+    #  visitor pushes into on re-entry.
+    if isinstance(arg, (itir.SymRef, itir.Literal)) or cpm.is_call_to(arg, "concat_where"):
+        return itir.FunCall(fun=shift_fun, args=[arg], type=arg.type)
+    return None
+
+
+def _shifted_branch(
+    shift_fun: itir.Expr, dim: common.Dimension, branch: itir.Expr
+) -> Optional[itir.Expr]:
+    match _dim_use(branch, dim):
+        case _DimUse.WITHOUT:
+            return branch
+        case _DimUse.WITH:
+            return _sink_shift(shift_fun, dim, branch)
+        case _:
+            return None
+
+
+def _node_count(node: itir.Node) -> int:
+    return sum(1 for _ in node.pre_walk_values().if_isinstance(itir.Node))
+
+
+#: Heuristic backstop: a `let` may not grow by more than this factor.
+#:
+#: One binding per distinct offset already bounds the copies structurally, so this is
+#: not what makes the rewrite bounded -- it is what makes the bound hold even for a
+#: shape the pass does not model. That matters because nothing downstream shares
+#: duplicated subtrees back together on the dace path.
+#:
+#: The value has to clear what a legitimate rewrite costs. A bound `concat_where` can
+#: be almost the whole `let`, in which case `n` distinct offsets legitimately reach
+#: `n + 1` times the original size; the dycore reads at `+-1`, so up to three times.
+#: The observed maximum in `compute_perturbed_quantities_and_interpolation` is 1.98x
+#: for a single offset, which is close enough to that ceiling to be worth stating.
+_MAX_LET_GROWTH_FACTOR = 4
+
+
+@dataclasses.dataclass
+class PushShiftIntoConcatWhere(eve.PreserveLocationVisitor, eve.NodeTranslator):
+    _uids: eve_utils.SequentialIDGenerator = dataclasses.field(
+        init=False,
+        repr=False,
+        default_factory=lambda: eve_utils.SequentialIDGenerator(prefix="_psh"),
+    )
+
+    @classmethod
+    def apply(cls, node: itir.Program) -> itir.Program:
+        return cls().visit(node)
+
+    def _fresh_sym(self, taken: set[str], type_: Optional[ts.TypeSpec]) -> itir.Sym:
+        while (name := next(self._uids)) in taken:
+            pass
+        return im.sym(name, type_)
+
+    def _push_into_concat_where(
+        self, shift_fun: itir.Expr, dim: common.Dimension, distance: int, concat_where: itir.FunCall
+    ) -> Optional[itir.Expr]:
+        """Distributes the shift `as_fieldop` `shift_fun` over `concat_where`, or declines."""
+        cond, true_branch, false_branch = concat_where.args
+        sym_domain = domain_utils.SymbolicDomain.from_expr(cond)
+        # A shift orthogonal to the condition leaves the condition untouched.
+        new_cond = _translate_cond(cond, dim, distance) if dim in sym_domain.ranges else cond
+
+        new_branches = [
+            _shifted_branch(shift_fun, dim, branch) for branch in (true_branch, false_branch)
+        ]
+        if any(branch is None for branch in new_branches):
+            return None
+
+        # The branches may themselves be `concat_where`s.
+        return self.visit(im.concat_where(new_cond, *new_branches))
+
+    def _bind_shifted_reads(self, node: itir.FunCall) -> itir.Expr:
+        """Binds every distinct shifted read of a `concat_where` parameter to a new sibling.
+
+        Nothing is committed before the rewrite has succeeded, so a parameter whose
+        shift cannot be sunk leaves no duplicated material behind.
+        """
+        assert isinstance(node.fun, itir.Lambda)
+        if not any(cpm.is_call_to(arg, "concat_where") for arg in node.args):
+            return node
+
+        body = node.fun.expr
+        taken = _bound_names(node)
+        new_params, new_args = list(node.fun.params), list(node.args)
+        rewritten: set[eve.concepts.SymbolName] = set()
+
+        for param, arg in zip(node.fun.params, node.args, strict=True):
+            if not cpm.is_call_to(arg, "concat_where"):
+                continue
+            # Substituting under a binder that shadows `param` would rewrite reads of a
+            #  different value; such a body is left alone rather than analyzed.
+            if _is_rebound(body, param.id):
+                continue
+            replacements: dict[tuple[common.Dimension, int], itir.Sym] = {}
+            for (dim, distance), shift_fun in _shifted_reads(body, param.id).items():
+                shifted = self._push_into_concat_where(shift_fun, dim, distance, arg)
+                if shifted is None:
+                    continue
+                sym = self._fresh_sym(taken, arg.type)
+                taken.add(str(sym.id))
+                replacements[(dim, distance)] = sym
+                new_params.append(sym)
+                new_args.append(shifted)
+            if replacements:
+                body = _ReplaceShiftedReads(param.id, replacements).visit(body)
+                rewritten.add(param.id)
+
+        if (added := len(new_params) - len(node.fun.params)) == 0:
+            return node
+
+        new_node = itir.FunCall(
+            fun=itir.Lambda(params=new_params, expr=body), args=new_args, type=node.type
+        )
+        # A new binding read only once is placed at that read instead, so the shifted
+        #  `concat_where` ends up in the same scope as the expression consuming it, and a
+        #  rewritten parameter whose last read was a shift is dropped. `inline_lambda`
+        #  renames the binders it moves under; substituting here would capture.
+        new_node = inline_lambdas.inline_lambda(
+            new_node,
+            opcount_preserving=True,
+            eligible_params=[param.id in rewritten for param in node.fun.params] + [True] * added,
+        )
+        if _node_count(new_node) > _MAX_LET_GROWTH_FACTOR * _node_count(node):
+            return node
+        return new_node
+
+    def visit_FunCall(self, node: itir.FunCall) -> itir.Expr:
+        node = self.generic_visit(node)
+
+        if cpm.is_let(node):
+            return self._bind_shifted_reads(node)
+
+        if not _is_plain_as_fieldop(node) or len(node.args) != 1:
+            return node
+        assert isinstance(node.fun, itir.FunCall)  # `_is_plain_as_fieldop`
+        shift_info = _shift_dim_and_distance(node.fun.args[0])
+        if shift_info is None:
+            return node
+        dim, distance = shift_info
+        if distance == 0:
+            return node
+
+        # Deliberately not looking through a binding, see the module docstring.
+        arg = node.args[0]
+        if not cpm.is_call_to(arg, "concat_where"):
+            return node
+
+        return self._push_into_concat_where(node.fun, dim, distance, arg) or node
+
+
+push_shifts = PushShiftIntoConcatWhere.apply

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -181,6 +181,9 @@ def apply_common_transforms(
     )  # domain inference does not support dynamic offsets yet
     ir = infer_domain_ops.InferDomainOps.apply(ir)
     ir = concat_where.canonicalize_domain_argument(ir)
+    # Must run before the domains are inferred and before `transform_to_as_fieldop`
+    #  turns the `concat_where` into an `if_` that a shift cannot be pushed through.
+    ir = concat_where.push_shifts(ir)
 
     ir = infer_domain.infer_program(
         ir,
@@ -300,6 +303,8 @@ def apply_fieldview_transforms(
     ir = infer_domain_ops.InferDomainOps.apply(ir)
     ir = concat_where.canonicalize_domain_argument(ir)
     ir = ConstantFolding.apply(ir)  # type: ignore[assignment]  # always an itir.Program
+    # See the comment on the same call in `apply_common_transforms`.
+    ir = concat_where.push_shifts(ir)
 
     ir = infer_domain.infer_program(
         ir,

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_concat_where_push_shifts.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_concat_where_push_shifts.py
@@ -205,6 +205,53 @@ def test_rebound_parameter_declines():
     assert _apply(testee) == testee
 
 
+def _scan(*args):
+    scan = im.call("scan")(
+        im.lambda_("acc", *(f"x{i}" for i in range(len(args))))(im.plus("acc", im.deref("x0"))),
+        im.literal_from_value(True),
+        im.literal_from_value(0.0),
+    )
+    result = im.as_fieldop(scan)(*args)
+    result.type = k_field
+    return result
+
+
+def test_binding_feeding_a_scan_declines():
+    """A `scan` argument is materialized either way, so the copies buy nothing."""
+    tmp = im.ref("tmp", k_field)
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(_scan(tmp, _shift(Koff, 1, tmp)))
+    assert _apply(testee) == testee
+
+
+def test_binding_feeding_a_scan_through_a_binding_declines():
+    """The use reaching the `scan` may be several bindings away."""
+    tmp = im.ref("tmp", k_field)
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(
+        im.let("q", im.as_fieldop(im.lambda_("x")(im.deref("x")))(tmp))(
+            _scan(im.ref("q", k_field), _shift(Koff, 1, tmp))
+        )
+    )
+    assert _apply(testee) == testee
+
+
+def test_binding_beside_an_unrelated_scan_still_fires():
+    """Only a `scan` the binding actually reaches may block the rewrite."""
+    tmp = im.ref("tmp", k_field)
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(
+        im.as_fieldop(im.lambda_("x", "y")(im.minus(im.deref("x"), im.deref("y"))))(
+            _scan(_b()), _shift(Koff, 1, tmp)
+        )
+    )
+    result = _apply(testee)
+    assert cpm.is_call_to(result.args[1], "concat_where")
+
+
 def _shift_chain(depth):
     """`depth` nested `let`s, each binding a `concat_where` reading the previous twice."""
     values = [im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())]

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_concat_where_push_shifts.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_concat_where_push_shifts.py
@@ -1,0 +1,282 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+from gt4py.next import common
+from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.ir_utils import (
+    common_pattern_matcher as cpm,
+    domain_utils,
+    ir_makers as im,
+)
+from gt4py.next.iterator.transforms import concat_where
+from gt4py.next.type_system import type_specifications as ts
+
+
+float_type = ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+KDim = common.Dimension(value="KDim", kind=common.DimensionKind.VERTICAL)
+IDim = common.Dimension(value="IDim", kind=common.DimensionKind.HORIZONTAL)
+k_field = ts.FieldType(dims=[KDim], dtype=float_type)
+
+Koff = im.cartesian_offset(KDim, KDim)
+
+
+def _a():
+    return im.ref("a", k_field)
+
+
+def _b():
+    return im.ref("b", k_field)
+
+
+Ioff = im.cartesian_offset(IDim, IDim)
+
+
+def _shift(offset, distance, arg):
+    """`as_fieldop(lambda it: deref(shift(offset, distance)(it)))(arg)`."""
+    return im.as_fieldop(im.lambda_("it")(im.deref(im.shift(offset, distance)("it"))))(arg)
+
+
+def _k_domain(start, stop):
+    return im.domain(common.GridType.CARTESIAN, {KDim: (start, stop)})
+
+
+def _apply(expr):
+    """Runs the pass on a program whose single statement is `expr`."""
+    program = itir.Program(
+        id="testee",
+        function_definitions=[],
+        params=[im.sym("out", k_field), im.sym("a", k_field), im.sym("b", k_field)],
+        declarations=[],
+        body=[itir.SetAt(expr=expr, domain=_k_domain(0, 10), target=im.ref("out", k_field))],
+    )
+    return concat_where.push_shifts(program).body[0].expr
+
+
+def test_shift_is_distributed_and_condition_translated():
+    testee = _shift(
+        Koff, 1, im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )
+    result = _apply(testee)
+
+    assert cpm.is_call_to(result, "concat_where")
+    # The boundary moves by `-distance`, so the shifted branch is only selected where
+    #  the original branch was valid at the shifted position.
+    new_range = domain_utils.SymbolicDomain.from_expr(result.args[0]).ranges[KDim]
+    assert new_range.stop == im.plus(im.literal_from_value(5), -1)
+    # Both branches carry the shift.
+    for branch in result.args[1:]:
+        assert cpm.is_applied_as_fieldop(branch)
+
+
+def test_shift_orthogonal_to_condition_leaves_condition_alone():
+    cond = im.domain(common.GridType.CARTESIAN, {IDim: (0, 5)})
+    testee = _shift(Koff, 1, im.concat_where(cond, _a(), _b()))
+    result = _apply(testee)
+
+    assert cpm.is_call_to(result, "concat_where")
+    assert result.args[0] == cond
+
+
+def test_shift_is_sunk_to_the_leaves():
+    """The shift must not come to rest on an intermediate, that is the fusion barrier."""
+    branch = im.as_fieldop(im.lambda_("x", "y")(im.plus(im.deref("x"), im.deref("y"))))(_a(), _b())
+    branch.type = k_field
+    testee = _shift(
+        Koff, 1, im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), branch, _b())
+    )
+    result = _apply(testee)
+
+    shifted_branch = result.args[1]
+    # the stencil of the branch is preserved and the shift moved onto its arguments
+    assert shifted_branch.fun == branch.fun
+    assert all(cpm.is_applied_as_fieldop(arg) for arg in shifted_branch.args)
+
+
+def test_zero_distance_is_not_pushed():
+    testee = _shift(
+        Koff, 0, im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )
+    assert _apply(testee) == testee
+
+
+def test_non_concat_where_argument_is_untouched():
+    testee = _shift(Koff, 1, im.ref("a", k_field))
+    assert _apply(testee) == testee
+
+
+def test_binding_read_through_shift_is_exposed():
+    """A multi use binding must be exposed; that is the shape the pass exists for."""
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(
+        im.as_fieldop(im.lambda_("x", "y")(im.minus(im.deref("x"), im.deref("y"))))(
+            im.ref("tmp", k_field), _shift(Koff, 1, im.ref("tmp", k_field))
+        )
+    )
+    result = _apply(testee)
+
+    # one read each, so neither of the two needs a binding: the unshifted use keeps the
+    #  original condition and the shifted one carries the translated condition
+    assert not cpm.is_let(result)
+    unshifted, shifted = result.args
+    assert cpm.is_call_to(unshifted, "concat_where")
+    assert cpm.is_call_to(shifted, "concat_where")
+    assert domain_utils.SymbolicDomain.from_expr(shifted.args[0]).ranges[KDim].stop == im.plus(
+        im.literal_from_value(5), -1
+    )
+
+
+def test_one_binding_per_distinct_distance():
+    """Duplication follows the number of distinct offsets, not the number of uses."""
+    tmp = im.ref("tmp", k_field)
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(
+        im.as_fieldop(im.lambda_("x", "y", "z")(im.plus(im.deref("x"), im.deref("y"))))(
+            _shift(Koff, 1, tmp), _shift(Koff, 1, tmp), _shift(Koff, -1, tmp)
+        )
+    )
+    result = _apply(testee)
+
+    # the two reads at `+1` share one binding, the single read at `-1` needs none
+    assert len(result.fun.params) == 1
+    first, second, third = result.fun.expr.args
+    assert cpm.is_ref_to(first, result.fun.params[0].id)
+    assert first == second
+    assert cpm.is_call_to(third, "concat_where")
+
+    # so the three reads leave one copy of the `concat_where` per distinct distance
+    assert sum(cpm.is_call_to(node, "concat_where") for node in result.pre_walk_values()) == 2
+
+
+def test_shared_binding_stays_in_the_outer_scope():
+    """A `concat_where` kept for several reads must not move under a shadowing binder."""
+    tmp = im.ref("tmp", k_field)
+    inner = im.lambda_(im.sym("a", k_field))(
+        im.as_fieldop(im.lambda_("x", "y")(im.plus(im.deref("x"), im.deref("y"))))(
+            _shift(Koff, 1, tmp), _shift(Koff, 1, tmp)
+        )
+    )
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(im.call(inner)(im.ref("b", k_field)))
+    result = _apply(testee)
+
+    # The binding sits where the original one was, outside the lambda that rebinds `a`,
+    #  so its reference to `a` still resolves to the outer one.
+    assert len(result.fun.params) == 1
+    assert cpm.is_call_to(result.args[0], "concat_where")
+    assert cpm.is_ref_to(result.args[0].args[1].args[0], "a")
+    assert str(result.fun.expr.fun.params[0].id) != "a"
+    # both reads share it
+    assert all(cpm.is_ref_to(arg, result.fun.params[0].id) for arg in result.fun.expr.fun.expr.args)
+
+
+def test_moving_a_binding_to_its_single_read_does_not_capture():
+    """The free variables of a `concat_where` moved to its read must not be captured."""
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(
+        im.call(im.lambda_(im.sym("a", k_field))(_shift(Koff, 1, im.ref("tmp", k_field))))(
+            im.ref("b", k_field)
+        )
+    )
+    result = _apply(testee)
+
+    # The inner parameter shadowed `a`, which the moved `concat_where` refers to, so
+    #  the inliner must have renamed it rather than capturing the reference.
+    assert isinstance(result.fun, itir.Lambda)
+    assert str(result.fun.params[0].id) != "a"
+
+
+def test_rebound_parameter_declines():
+    """A body that shadows the parameter is left alone rather than substituted into."""
+    testee = im.let(
+        "tmp", im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())
+    )(
+        im.call(im.lambda_(im.sym("tmp", k_field))(_shift(Koff, 1, im.ref("tmp", k_field))))(
+            im.ref("b", k_field)
+        )
+    )
+    assert _apply(testee) == testee
+
+
+def _shift_chain(depth):
+    """`depth` nested `let`s, each binding a `concat_where` reading the previous twice."""
+    values = [im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), _a(), _b())]
+    for i in range(1, depth + 1):
+        previous = im.ref(f"t{i - 1}", k_field)
+        shifted = [_shift(Koff, 1, previous) for _ in range(2)]
+        for expr in shifted:
+            expr.type = k_field
+        branch = im.as_fieldop(im.lambda_("x", "y")(im.plus(im.deref("x"), im.deref("y"))))(
+            *shifted
+        )
+        branch.type = k_field
+        values.append(im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), branch, _b()))
+    expr = im.ref(f"t{depth}", k_field)
+    for i in reversed(range(depth + 1)):
+        expr = im.let(f"t{i}", values[i])(expr)
+    return expr
+
+
+def _node_count(node):
+    return sum(1 for _ in node.pre_walk_values().if_isinstance(itir.Node))
+
+
+def test_deep_shift_chain_stays_linear():
+    """Every level of the chain doubles the shifted reads, so per use duplication is exponential.
+
+    A linear implementation stays below a factor of two here; the bound is set at three
+    so that only a genuine change of complexity trips it.
+    """
+    for depth in (1, 5, 10):
+        testee = _shift_chain(depth)
+        assert _node_count(_apply(testee)) <= 3 * _node_count(testee)
+
+
+def test_scan_branch_declines():
+    """Sinking into a scan would run the fold over a different range."""
+    scan = im.call("scan")(
+        im.lambda_("acc", "x")(im.plus("acc", im.deref("x"))),
+        im.literal_from_value(True),
+        im.literal_from_value(0.0),
+    )
+    branch = im.as_fieldop(scan)(_a())
+    branch.type = k_field
+    testee = _shift(
+        Koff, 1, im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), branch, _b())
+    )
+    assert _apply(testee) == testee
+
+
+def test_explicit_domain_branch_declines():
+    """An explicit domain argument would be left stale by the rewrite."""
+    branch = im.as_fieldop(im.lambda_("x")(im.deref("x")), _k_domain(0, 10))(_a())
+    branch.type = k_field
+    testee = _shift(
+        Koff, 1, im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), branch, _b())
+    )
+    assert _apply(testee) == testee
+
+
+def test_untyped_branch_declines():
+    """Without a type the pass cannot tell whether the dimension is present."""
+    testee = _shift(Koff, 1, im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), "a", "b"))
+    assert _apply(testee) == testee
+
+
+def test_compound_leaf_declines():
+    """Leaving the shift on a compound intermediate is the shape the pass removes."""
+    leaf = im.tuple_get(0, im.make_tuple(_a(), _b()))
+    leaf.type = k_field
+    branch = im.as_fieldop(im.lambda_("x")(im.deref("x")))(leaf)
+    branch.type = k_field
+    testee = _shift(
+        Koff, 1, im.concat_where(_k_domain(itir.InfinityLiteral.NEGATIVE, 5), branch, _b())
+    )
+    assert _apply(testee) == testee


### PR DESCRIPTION
Upstream issue: GridTools/gt4py#2793.

**Staged on the fork — not yet proposed upstream.** Stacked on #74, which is a **hard dependency**: this pass can translate a condition so a branch is selected on an empty region, and deliberately leaves detecting that to `prune_empty_concat_where`. Base is set to that branch so the diff shows only this change.

## What it does

A shifted read of a `concat_where` result tends to be materialized, because the `concat_where` blocks the usual escape of moving the shift onto the producer's own inputs. The pass moves the shift into the branches and translates the condition with it:

```
as_fieldop(lambda it: deref(shift(K, d)(it)))(concat_where(u<K: [lo, hi[>, a, b))
  ->  concat_where(u<K: [lo - d, hi - d[>, shift_d(a), shift_d(b))
```

Sinking to the leaves is load bearing, not an optimization — stopping at an intermediate leaves the very barrier the pass exists to remove, and measured *worse* than not rewriting. Translating the condition with the expression is what makes it safe: a branch may be readable on a wider index range than it is selected on.

Why it is materialized in the icon4py dycore programs measured here is backend specific. On gtfn it is `fuse_as_fieldop._arg_inline_predicate` declining to inline an `as_fieldop` that is accessed at a non-center shift — though not unconditionally, a single argument applied fieldop is inlined regardless of shifts. On dace there is no GTIR fusion at all; the barrier is `MapFusionVertical`, which requires pointwise write and read subsets on the SDFG.

## Where this comes from

A `concat_where` giving the boundary level a different source than the interior, read one level up by its consumer:

```python
@gtx.field_operator
def theta_on_half_levels(interior: CKField, surface: CKField) -> CKField:
    return concat_where(K < 1, surface, interior)

@gtx.field_operator
def vertical_difference(interior: CKField, surface: CKField) -> CKField:
    theta = theta_on_half_levels(interior, surface)
    return theta(Koff[1]) - theta
```

lowers to, before any pass runs:

```
theta_on_half_levels = concat_where(Kᵥ < 1, surface, interior)
vertical_difference = (λ(thetaᐞ0) →
   (⇑(λ(__arg0, __arg1) → ·__arg0 - ·__arg1))((⇑(λ(__it) → ·⟪Koffₒ, 1ₒ⟫(__it)))(thetaᐞ0), thetaᐞ0))(
  theta_on_half_levels(interior, surface)
)
```

`thetaᐞ0` is read once at `Koff[1]` and once unshifted, so it is materialized. This is the icon4py dycore shape: a vertical boundary treated by `concat_where`, consumed by a vertical difference.

## Examples

The basic rewrite, shift distributes and the condition translates:

```
before: (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(concat_where(c⟨ KDimᵥ: [-∞, 5[ ⟩, a, b))

after:  concat_where(c⟨ KDimᵥ: [-∞, 5 + -1[ ⟩,
                     (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(a),
                     (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(b))
```

A shift orthogonal to the condition leaves the condition alone — condition on `K`, shift on `I`:

```
before: (⇑(λ(it) → ·⟪IDimₕ→IDimₕ, 1ₒ⟫(it)))(concat_where(c⟨ KDimᵥ: [-∞, 5[ ⟩, a, b))

after:  concat_where(c⟨ KDimᵥ: [-∞, 5[ ⟩, a, b)
```

Sinking reaches the leaves, not just the first `concat_where`. Stopping at the outer one would leave the barrier in place:

```
before: (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(
          concat_where(c⟨ KDimᵥ: [-∞, 5[ ⟩, (⇑(λ(x, y) → ·x + ·y))(a, b), b)
        )

after:  concat_where(c⟨ KDimᵥ: [-∞, 5 + -1[ ⟩,
                     (⇑(λ(x, y) → ·x + ·y))(
                       (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(a),
                       (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(b)
                     ),
                     (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(b))
```

A zero distance shift is left alone:

```
before: (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 0ₒ⟫(it)))(concat_where(c⟨ KDimᵥ: [-∞, 5[ ⟩, a, b))

after:  unchanged
```

One sibling binding per distinct distance, not one per use site. Here `t` is read at `+1`, at `-1` and unshifted, so the rewrite produces one translated `concat_where` per distance and leaves the unshifted read on the original:

```
before: (λ(t) → (⇑(λ(__arg0, __arg1) → ·__arg0 + ·__arg1))(
                  (⇑(λ(__arg0, __arg1) → ·__arg0 + ·__arg1))(
                    (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(t),
                    (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, -1ₒ⟫(it)))(t)
                  ), t
                ))(concat_where(c⟨ KDimᵥ: [-∞, 5[ ⟩, a, b))

after:  (⇑(λ(__arg0, __arg1) → ·__arg0 + ·__arg1))(
          (⇑(λ(__arg0, __arg1) → ·__arg0 + ·__arg1))(
            concat_where(c⟨ KDimᵥ: [-∞, 5 + -1[ ⟩,
                         (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(a),
                         (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, 1ₒ⟫(it)))(b)),
            concat_where(c⟨ KDimᵥ: [-∞, 5 + 1[ ⟩,
                         (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, -1ₒ⟫(it)))(a),
                         (⇑(λ(it) → ·⟪KDimᵥ→KDimᵥ, -1ₒ⟫(it)))(b))),
          concat_where(c⟨ KDimᵥ: [-∞, 5[ ⟩, a, b)
        )
```

## The two commits

1. **the pass**, including one sibling binding per distinct shift distance rather than inlining at every use site, plus a node count backstop.
2. **a scan profitability guard**, separately revertible.

The per-offset binding is not cosmetic. The first version inlined the binding at every use site; on `z_alpha` (4 uses, only 2 of them shifts) that turned 1 computation into 4. It matters on dace specifically because **`apply_fieldview_transforms` has neither `fuse_as_fieldop` nor CSE**, so nothing downstream re-shares the copies — the same rewrite costs +8 IR nodes on gtfn and +305 on dace.

The backstop factor is **measured, not guessed**: the largest legitimate `let` growth observed is 1.977x, so a factor of 2 would have sat 1% above wanted work. It is 4, and verified never to fire.

The scan guard is a **profitability** heuristic, not a legality one: a binding that transitively feeds an `as_fieldop(scan(...))` is declined, on the grounds that a scan argument is materialized anyway so there is no barrier left to remove. Deliberately over-approximate. Worth reviewing on its own terms — it means a program where the rewrite *would* pay through a scan gets declined.

## Measurements (GH200, icon4py mch_icon-ch1_medium, 1800 calls)

Target program is `compute_perturbed_quantities_and_interpolation`.

| | target program | model total |
|---|---|---|
| without the pass | 0.5189 | 5.6960 |
| pass without the guard | 0.4282 / 0.4271 | 5.7895 / 5.8111 |
| with both commits | **0.4285 / 0.4279** | **5.6511 / 5.6314** |

Two independent runs each; run-to-run spread on the total is 0.0197 s. So **-0.045 to -0.065 s** at model level, and note the middle row: **without the scan guard this pass is a net regression** despite making `compute_perturbed_quantities_and_interpolation` 17% faster. A program-local win did not imply a model-level win.

## Testing

`tests/next_tests/unit_tests/iterator_tests/`: 518 passed (500 on `main`), 1 skipped, 2 xfailed. Includes a depth test asserting node count stays linear in `let` chain depth — verified to fail against the pre-fix implementation, which grew ~2.4x per level and reached 52.9x by depth 6.
