### PR TITLE
fix[next]: decide concat_where pruning from the branches' domains

### DIFF
--- a/docs/development/ADRs/cartesian/frontend/IntEnum.md
+++ b/docs/development/ADRs/cartesian/frontend/IntEnum.md
@@ -1,0 +1,39 @@
+# IntEnum frontend support
+
+The frontend is not supporting 3.11+ `IntEnum` - which are very useful to express flags and control flow in a structured way. We build the support for the following code as an example of a canonical use:
+
+```python
+@gtscript.enum
+class MyEnum(IntEnum):
+    A = 42
+    B = 1000
+
+
+@gtscript.stencil
+def enum(field: gtscript.Field[float], order: MyEnum):  # type: ignore
+    with computation(PARALLEL), interval(0, 1):
+        if order > MyEnum.A:
+            field[0, 0, 0] = MyEnum.B
+```
+
+## Context
+
+`IntEnum` enforces a type consistency in the elements of `Enum` making it a safe way to express flags and integer constants. It is standard AST as of 3.11+. Supporting in `gt4py.cartesian` would allow a modern python expression to be supported and clean up code around a very common behavior of users to write in hardcoded flag values.
+
+Futher development would allow generic `Enum` with valid types of elements (`float`, `bool`) while disallowing unsupported runtime types (`str`).
+
+## Decision
+
+Implementation presents a `@gtscript.enum` construct which registers `Enum` for use within `gt4py.cartesian`.
+
+We will replace all instances of those enum in stencils by their constant values, allowing the implementation to be focused on the frontend and not downstream into the IRs.
+
+## Consequences
+
+`IntEnum` are considered frozen - if the value is swapped during runtime it won't be reflected.
+
+## Alternatives considered
+
+`IntEnum` can be emulated with a naming convention and simple constants defined in at a Module level. But `Enum` guarantees structure, docstrings and can even be extended for non runtime operations with methods.
+
+We could expand the system to all `Enum` by introducing a type check during registration of the enum in gt4py making sure the type of the parameters are legitimate in the context of `gt4py.cartesian`.

--- a/src/gt4py/cartesian/definitions.py
+++ b/src/gt4py/cartesian/definitions.py
@@ -43,6 +43,22 @@ LITERAL_FLOAT_PRECISION = int(
 """Default literal precision used for unspecific `float` types and casts."""
 
 
+def get_integer_type(literal_integer_precision: int):
+    """Return the integer numpy type corresponding to the LITERAL_INT_PRECISION set."""
+    # I'd love to return `numpy.signedinteger[LITERAL_INT_PRECISION]` but that won't work
+    match literal_integer_precision:
+        case 8:
+            return numpy.int8
+        case 16:
+            return numpy.int16
+        case 32:
+            return numpy.int32
+        case 64:
+            return numpy.int64
+        case _:
+            raise NotImplementedError("Unknown integer precision type")
+
+
 @enum.unique
 class AccessKind(enum.IntFlag):
     NONE = 0

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -33,6 +33,7 @@ from typing import (
 import numpy as np
 
 from gt4py.cartesian import definitions as gt_definitions, gtscript, utils as gt_utils
+from gt4py.cartesian.definitions import LITERAL_INT_PRECISION
 from gt4py.cartesian.frontend import node_util, nodes
 from gt4py.cartesian.frontend.base import Frontend, register
 from gt4py.cartesian.frontend.defir_builder import DefIRBuilder
@@ -442,6 +443,18 @@ class ValueInliner(ast.NodeTransformer):
         return node
 
     def visit_Attribute(self, node: ast.Attribute):
+        # An enum MyEnum.A would come has
+        # > ast.Attribute("A")
+        #   - value: ast.Name("MyEnum")
+        # We want to replace the entire thing - so we capture the top level
+        # attribute. We don't use the `self.context` because of this
+        # two-step AST structure which doesn't fit the generic `replace_node`.
+
+        if isinstance(node.value, ast.Name) and node.value.id in _ENUM_REGISTER.keys():
+            int_value = getattr(_ENUM_REGISTER[node.value.id], node.attr)
+            return ast.Constant(value=int_value)
+
+        # Common replace for all other nodes in context.
         return self._replace_node(node)
 
     def visit_Name(self, node: ast.Name):
@@ -2065,6 +2078,11 @@ class CollectLocalSymbolsAstVisitor(ast.NodeVisitor):
                     raise invalid_target
 
 
+_ENUM_REGISTER: dict[str, object] = {}
+"""Register of IntEnum that will be available to parsing in stencils. Register
+with @gtscript.enum()"""
+
+
 class GTScriptParser(ast.NodeVisitor):
     CONST_VALUE_TYPES = (
         *gtscript._VALID_DATA_TYPES,
@@ -2155,6 +2173,13 @@ class GTScriptParser(ast.NodeVisitor):
                 and param.annotation in gtscript._VALID_DATA_TYPES
             ):
                 dtype_annotation = np.dtype(param.annotation)
+            elif param.annotation in _ENUM_REGISTER.values():
+                literal_int_precision = (
+                    options.literal_int_precision if options else LITERAL_INT_PRECISION
+                )
+                dtype_annotation = gt_definitions.get_integer_type(
+                    literal_int_precision
+                )  # We will replace all enums with `int`
             elif param.annotation is inspect.Signature.empty:
                 dtype_annotation = None
             else:
@@ -2283,6 +2308,10 @@ class GTScriptParser(ast.NodeVisitor):
         imported_symbols = {name: {} for name in imported_names}
         local_symbols = CollectLocalSymbolsAstVisitor.apply(gtscript_ast)
         nonlocal_symbols = {}
+
+        # Remove enums from `context`, they will be turned into integers in the ValueReplacer
+        for enum_ in _ENUM_REGISTER.keys():
+            context.pop(enum_, "")
 
         name_nodes = gt_meta.collect_names(gtscript_ast, skip_annotations=False)
         for collected_name in name_nodes.keys():
@@ -2418,6 +2447,20 @@ class GTScriptParser(ast.NodeVisitor):
             resolved_values_list = []
 
         return result
+
+    @staticmethod
+    def register_enum(class_: type[enum.IntEnum]):
+        class_name = class_.__name__
+        if class_name in _ENUM_REGISTER:
+            raise ValueError(
+                f"Enum names must be unique. @gtscript.enum {class_name} is already taken."
+            )
+
+        if not issubclass(class_, enum.IntEnum):
+            raise ValueError(f"Enum {class_name} needs to derive from `enum.IntEnum`.")
+
+        _ENUM_REGISTER[class_name] = class_
+        return class_
 
     def extract_arg_descriptors(self):
         api_signature = self.definition._gtscript_["api_signature"]

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -50,7 +50,6 @@ from gt4py.cartesian.utils import meta as gt_meta, warn_experimental_feature
 
 
 PYTHON_AST_VERSION: Final = (3, 12)
-ELLIPSIS_TYPE = getattr(ast, "Ellipsis", types.EllipsisType)
 
 
 class AssertionChecker(ast.NodeTransformer):
@@ -751,10 +750,11 @@ class CallInliner(ast.NodeTransformer):
         return result_node
 
     def visit_Expr(self, node: ast.Expr):
-        """Ignore pure string statements in callee."""
-        pure_str_types = (ast.Constant,) + ((ast.Str,) if hasattr(ast, "Str") else ())
-        if not isinstance(node.value, pure_str_types):
-            return super().visit(node.value)
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            # Ignore pure string statements in callee
+            return
+
+        return super().visit(node.value)
 
 
 class CompiledIfInliner(ast.NodeTransformer):
@@ -1372,7 +1372,7 @@ class IRMaker(ast.NodeVisitor):
 
         if any(isinstance(cn, ast.Slice) for cn in index_nodes):
             raise GTScriptSyntaxError(message="Invalid target in assignment.", loc=node)
-        if any(isinstance(cn, ELLIPSIS_TYPE) for cn in index_nodes):
+        if any(isinstance(cn, types.EllipsisType) for cn in index_nodes):
             return None
 
         # Determine if we are using the new-style axis syntax, or the old style.

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -16,6 +16,7 @@ import collections
 import inspect
 import numbers
 import types
+from enum import IntEnum
 from typing import Callable, Dict, Type, Union
 
 import numpy as np
@@ -157,6 +158,14 @@ def _set_arg_dtypes(definition: Callable[..., None], dtypes: Dict[Type, Type]):
     for key, value in annotations.items():
         annotations[key] = _parse_annotation(key, value)
     return original_annotations
+
+
+def enum(class_: type[IntEnum]):
+    """Mark an IntEnum derived class as readable for GT4Py."""
+    from gt4py.cartesian.frontend import gtscript_frontend as gt_frontend
+
+    gt_frontend.GTScriptParser.register_enum(class_)
+    return class_
 
 
 def function(func: Callable) -> Callable:

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -20,7 +20,15 @@ from typing import Any, Callable, ClassVar, Literal, Union, cast
 import numpy as np
 
 from gt4py.cartesian import backend as gt_backend
-from gt4py.cartesian.definitions import AccessKind, DomainInfo, FieldInfo, ParameterInfo
+from gt4py.cartesian.definitions import (
+    LITERAL_INT_PRECISION,
+    AccessKind,
+    DomainInfo,
+    FieldInfo,
+    ParameterInfo,
+    get_integer_type,
+)
+from gt4py.cartesian.frontend import gtscript_frontend
 from gt4py.cartesian.gtc import utils as gtc_utils
 from gt4py.cartesian.gtc.definitions import Index, Shape
 from gt4py.storage.cartesian import utils as storage_utils
@@ -563,8 +571,18 @@ class StencilObject(abc.ABC):
             exec_info["call_run_start_time"] = time.perf_counter()
         backend_cls = gt_backend.from_name(self.backend)
         device = backend_cls.storage_info["device"]
-        array_infos = _extract_array_infos(field_args, device)
 
+        # Normalize `gtscript.enum` to integers
+        literal_int_precision = (
+            self.options["literal_int_precision"]
+            if "literal_int_precision" in self.options
+            else LITERAL_INT_PRECISION
+        )
+        for name, value in parameter_args.items():
+            if type(value) in gtscript_frontend._ENUM_REGISTER.values():
+                parameter_args[name] = get_integer_type(literal_int_precision)(value.value)
+
+        array_infos = _extract_array_infos(field_args, device)
         cache_key = _compute_domain_origin_cache_key(array_infos, parameter_args, domain, origin)
         if cache_key not in self._domain_origin_cache:
             origin = self._normalize_origins(array_infos, self.field_info, origin)

--- a/src/gt4py/next/iterator/ir_utils/domain_utils.py
+++ b/src/gt4py/next/iterator/ir_utils/domain_utils.py
@@ -353,6 +353,20 @@ def promote_domain(
     return SymbolicDomain(domain.grid_type, dims_dict)
 
 
+def concat_where_branch_domain(
+    domain: SymbolicDomain, cond: SymbolicDomain, is_true_branch: bool
+) -> SymbolicDomain:
+    """
+    Return the part of `domain` on which one branch of a `concat_where` is selected.
+
+    Note: the complement is taken before promoting to the dimensions of `domain`, since
+    `domain_complement` requires each range to be infinite on exactly one side, which a
+    promoted dimension is not.
+    """
+    region = cond if is_true_branch else domain_complement(cond)
+    return domain_intersection(domain, promote_domain(region, domain.ranges.keys()))
+
+
 def is_finite(range_or_domain: SymbolicRange | SymbolicDomain) -> bool:
     """
     Return whether a range is unbounded in (at least) one direction.

--- a/src/gt4py/next/iterator/transforms/concat_where/__init__.py
+++ b/src/gt4py/next/iterator/transforms/concat_where/__init__.py
@@ -6,6 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from gt4py.next.iterator.transforms.concat_where.broadcast_branches import broadcast_branches
 from gt4py.next.iterator.transforms.concat_where.canonicalize_domain_argument import (
     canonicalize_domain_argument,
 )
@@ -15,4 +16,9 @@ from gt4py.next.iterator.transforms.concat_where.transform_to_as_fieldop import 
 )
 
 
-__all__ = ["canonicalize_domain_argument", "expand_tuple_args", "transform_to_as_fieldop"]
+__all__ = [
+    "broadcast_branches",
+    "canonicalize_domain_argument",
+    "expand_tuple_args",
+    "transform_to_as_fieldop",
+]

--- a/src/gt4py/next/iterator/transforms/concat_where/broadcast_branches.py
+++ b/src/gt4py/next/iterator/transforms/concat_where/broadcast_branches.py
@@ -1,0 +1,85 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Optional, TypeVar
+
+from gt4py.eve import NodeTranslator, PreserveLocationVisitor
+from gt4py.next import common
+from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm, ir_makers as im
+from gt4py.next.iterator.type_system import inference as type_inference
+from gt4py.next.type_system import type_info, type_specifications as ts
+
+
+NODE = TypeVar("NODE", bound=itir.Node)
+
+
+def _dims(type_: Optional[ts.TypeSpec]) -> Optional[list[common.Dimension]]:
+    if isinstance(type_, (ts.FieldType, ts.ScalarType)):
+        return type_info.extract_dims(type_)
+    return None
+
+
+class _BroadcastBranches(PreserveLocationVisitor, NodeTranslator):
+    """
+    Make the implicit broadcast of `concat_where` branches explicit.
+
+    A `concat_where` broadcasts a branch to the dimensions that only occur in the condition or in
+     the other branch, e.g.
+
+    >>> from gt4py.next.iterator.ir_utils import ir_makers as im
+    >>> from gt4py.next.type_system import type_specifications as ts
+    >>> Vertex = common.Dimension("Vertex")
+    >>> K = common.Dimension("K", kind=common.DimensionKind.VERTICAL)
+    >>> float64 = ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+    >>> expr = im.concat_where(
+    ...     im.domain(common.GridType.UNSTRUCTURED, {K: (itir.InfinityLiteral.NEGATIVE, 0)}),
+    ...     im.ref("a", ts.FieldType(dims=[Vertex], dtype=float64)),
+    ...     im.ref("b", ts.FieldType(dims=[Vertex, K], dtype=float64)),
+    ... )
+    >>> print(broadcast_branches(expr))
+    concat_where(u⟨ Kᵥ: [-∞, 0[ ⟩, broadcast(a, {Vertexₕ, Kᵥ}), b)
+
+    Domain inference restricts the domain of an expression to the dimensions of its type, so
+     without the explicit `broadcast` the domain a branch is selected on is lost in exactly the
+     dimensions that make it empty.
+    """
+
+    @classmethod
+    def apply(
+        cls, node: NODE, *, offset_provider_type: Optional[common.OffsetProviderType] = None
+    ) -> NODE:
+        node = type_inference.reinfer(node, offset_provider_type=offset_provider_type)
+        return cls().visit(node)
+
+    def visit_FunCall(self, node: itir.FunCall) -> itir.Expr:
+        node = self.generic_visit(node)
+
+        if cpm.is_call_to(node, "concat_where"):
+            dims = _dims(node.type)
+            if dims is None:
+                return node
+            cond, *branches = node.args
+            new_branches = [
+                im.call("broadcast")(
+                    branch,
+                    im.make_tuple(
+                        *(itir.AxisLiteral(value=dim.value, kind=dim.kind) for dim in dims)
+                    ),
+                )
+                if _dims(branch.type) not in (None, dims)
+                else branch
+                for branch in branches
+            ]
+            if new_branches != branches:
+                return im.call(node.fun)(cond, *new_branches)
+
+        return node
+
+
+broadcast_branches = _BroadcastBranches.apply

--- a/src/gt4py/next/iterator/transforms/infer_domain.py
+++ b/src/gt4py/next/iterator/transforms/infer_domain.py
@@ -364,19 +364,14 @@ def _infer_concat_where(
     actual_domains: AccessedDomains = {}
     cond, true_field, false_field = expr.args
     symbolic_cond = domain_utils.SymbolicDomain.from_expr(cond)
-    cond_complement = domain_utils.domain_complement(symbolic_cond)
 
-    for arg in [true_field, false_field]:
+    for is_true_branch, arg in [(True, true_field), (False, false_field)]:
 
         @tree_map
         def mapper(d: NonTupleDomainAccess):
             if isinstance(d, DomainAccessDescriptor):
                 return d
-            promoted_cond = domain_utils.promote_domain(
-                symbolic_cond if arg == true_field else cond_complement,  # noqa: B023 # function is never used outside the loop
-                d.ranges.keys(),
-            )
-            return domain_utils.domain_intersection(d, promoted_cond)
+            return domain_utils.concat_where_branch_domain(d, symbolic_cond, is_true_branch)  # noqa: B023 # function is never used outside the loop
 
         domain_ = mapper(domain)
 

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -180,6 +180,7 @@ def apply_common_transforms(
         ir, offset_provider_type=offset_provider_type, uids=uids
     )  # domain inference does not support dynamic offsets yet
     ir = infer_domain_ops.InferDomainOps.apply(ir)
+    ir = concat_where.broadcast_branches(ir, offset_provider_type=offset_provider_type)
     ir = concat_where.canonicalize_domain_argument(ir)
 
     ir = infer_domain.infer_program(
@@ -298,6 +299,7 @@ def apply_fieldview_transforms(
     )  # domain inference does not support dynamic offsets yet
 
     ir = infer_domain_ops.InferDomainOps.apply(ir)
+    ir = concat_where.broadcast_branches(ir, offset_provider_type=offset_provider_type)
     ir = concat_where.canonicalize_domain_argument(ir)
     ir = ConstantFolding.apply(ir)  # type: ignore[assignment]  # always an itir.Program
 

--- a/src/gt4py/next/iterator/transforms/prune_empty_concat_where.py
+++ b/src/gt4py/next/iterator/transforms/prune_empty_concat_where.py
@@ -36,7 +36,9 @@ class _PruneEmptyConcatWhere(PreserveLocationVisitor, NodeTranslator):
 
     A branch that does not span all dimensions of the `concat_where` is neither recognized as
      never selected, since its domain has no range in the missing dimension, nor usable as a
-     replacement for the entire expression, since that would drop a dimension.
+     replacement for the entire expression, since that would drop a dimension. Execute
+     `gt4py.next.iterator.transforms.concat_where.broadcast_branches` before to give every branch
+     the dimensions of the `concat_where`.
 
     >>> from gt4py.next.iterator.ir_utils import domain_utils, ir_makers as im
     >>> from gt4py.next.iterator.transforms import concat_where, infer_domain

--- a/src/gt4py/next/iterator/transforms/prune_empty_concat_where.py
+++ b/src/gt4py/next/iterator/transforms/prune_empty_concat_where.py
@@ -9,19 +9,10 @@ import dataclasses
 from typing import TypeVar
 
 from gt4py.eve import NodeTranslator, PreserveLocationVisitor
-from gt4py.eve.extended_typing import Container, Self
+from gt4py.eve.extended_typing import Self
 from gt4py.next import common
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm, domain_utils
-
-
-def _filter_domain(
-    domain: domain_utils.SymbolicDomain, dims: Container[common.Dimension]
-) -> domain_utils.SymbolicDomain:
-    return domain_utils.SymbolicDomain(
-        grid_type=domain.grid_type,
-        ranges={d: r for d, r in domain.ranges.items() if d in dims},
-    )
 
 
 PRG = TypeVar("PRG", bound=itir.Program | itir.Expr)
@@ -32,14 +23,36 @@ class _PruneEmptyConcatWhere(PreserveLocationVisitor, NodeTranslator):
     """
     Prune `concat_where` expression with one branch never being accessed.
 
-    This pass requires domain inference to be executed before.
+    Whether a branch is ever selected is decided from the domains of the branches themselves: a
+     branch is selected on its own domain restricted to the condition, or to the complement of the
+     condition for the false branch.
+
+    This pass requires domain inference to be executed before. In particular it relies on the
+     condition being in the canonical form that domain inference already requires, i.e. bounded on
+     exactly one side, as the complement of the condition is not defined otherwise.
 
     This pass the true and false branch values to be fields, not tuples of fields. Execute
      `gt4py.next.iterator.transforms.concat_where.expand_tuple_args` before.
 
-    >>> from gt4py.next.iterator.ir_utils import ir_makers as im
+    A branch that does not span all dimensions of the `concat_where` is neither recognized as
+     never selected, since its domain has no range in the missing dimension, nor usable as a
+     replacement for the entire expression, since that would drop a dimension.
+
+    >>> from gt4py.next.iterator.ir_utils import domain_utils, ir_makers as im
+    >>> from gt4py.next.iterator.transforms import concat_where, infer_domain
     >>> IDim = common.Dimension("IDim")
-    >>> expr = im.concat_where(im.domain(common.GridType.UNSTRUCTURED, {IDim: (0, 0)}), "a", "b")
+    >>> expr = im.concat_where(
+    ...     im.domain(common.GridType.CARTESIAN, {IDim: (10, itir.InfinityLiteral.POSITIVE)}),
+    ...     "a",
+    ...     "b",
+    ... )
+    >>> expr, _ = infer_domain.infer_expr(
+    ...     concat_where.canonicalize_domain_argument(expr),
+    ...     domain_utils.SymbolicDomain.from_expr(
+    ...         im.domain(common.GridType.CARTESIAN, {IDim: (0, 10)})
+    ...     ),
+    ...     offset_provider={},
+    ... )
     >>> assert prune_empty_concat_where(expr) == im.ref("b")
     """
 
@@ -61,17 +74,27 @@ class _PruneEmptyConcatWhere(PreserveLocationVisitor, NodeTranslator):
                 return tb
 
             cond = domain_utils.SymbolicDomain.from_expr(cond_expr)
-            if cond.empty():
-                return node.args[2]
+            branch_domains = [arg.annex.domain for arg in (tb, fb)]
+            if not all(
+                isinstance(domain, domain_utils.SymbolicDomain) for domain in branch_domains
+            ):
+                return node
 
-            tb_domain, fb_domain = (
-                _filter_domain(arg.annex.domain, cond.ranges.keys()) for arg in node.args[1:]
+            # a branch is implicitly broadcast to the dimensions it does not have itself, so the
+            #  `concat_where` spans the dimensions of the condition and of both branches
+            dims: dict[common.Dimension, None] = dict.fromkeys(
+                [*cond.ranges, *(dim for domain in branch_domains for dim in domain.ranges)]
             )
-            assert all(isinstance(d, domain_utils.SymbolicDomain) for d in (tb_domain, fb_domain))
-            if tb_domain.empty():
-                return node.args[2]
-            if fb_domain.empty():
-                return node.args[1]
+
+            for is_true_branch in (True, False):
+                pruned, kept = (tb, fb) if is_true_branch else (fb, tb)
+                selected = domain_utils.concat_where_branch_domain(
+                    domain_utils.promote_domain(pruned.annex.domain, dims), cond, is_true_branch
+                )
+                # the kept branch replaces the entire expression as is, so pruning to it would
+                #  drop the dimensions it is implicitly broadcast to
+                if selected.empty() and kept.annex.domain.ranges.keys() == dims.keys():
+                    return kept
 
         return node
 

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -6,6 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from enum import IntEnum
 import numpy as np
 import pytest
 
@@ -1853,3 +1854,39 @@ def test_offset_j_in_temporaries(backend: str) -> None:
                 if isnan(sqrt_res)
                 else 0.0
             )
+
+
+@gtscript.enum
+class MyEnum(IntEnum):
+    Zero = 0
+    A = 10
+    B = 20
+    C = 30
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_enum_runtime(backend):
+
+    @gtscript.stencil(backend=backend)
+    def the_stencil(out_field: Field[int], order: MyEnum):  # type: ignore
+        with computation(PARALLEL), interval(0, 1):
+            out_field = 32
+            if order < MyEnum.A:
+                out_field = MyEnum.A
+
+        with computation(PARALLEL), interval(1, 2):
+            out_field = 23
+            out_field = MyEnum.B
+
+        with computation(PARALLEL), interval(2, None):
+            out_field = 56
+            out_field = MyEnum.C
+
+    domain = (5, 5, 5)
+    out_arr = gt_storage.zeros(backend=backend, shape=domain, dtype=int)
+
+    the_stencil(out_arr, MyEnum.Zero)
+
+    assert out_arr[0, 0, 0] == MyEnum.A.value
+    assert out_arr[0, 0, 1] == MyEnum.B.value
+    assert (out_arr[0, 0, 2:] == MyEnum.C.value).all()

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -6,6 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from enum import IntEnum, StrEnum, Enum
 import inspect
 import functools
 import textwrap
@@ -2476,3 +2477,66 @@ class TestIteratorAccess:
                 name=inspect.stack()[0][3],
                 module=self.__class__.__name__,
             )
+
+
+@gtscript.enum
+class LocalEnum(IntEnum):
+    A = 42
+    B = 1000
+
+
+class TestEnum:
+    def setup_method(self):
+        def enum(field: gtscript.Field[float], order: LocalEnum):  # type: ignore
+            with computation(PARALLEL), interval(0, 1):
+                if order > LocalEnum.A:
+                    field[0, 0, 0] = LocalEnum.B
+
+        self.stencil = enum
+
+    @pytest.mark.parametrize("integer_precision", [32, 64])
+    def test_enum_in_stencil(self, integer_precision):
+        def_ir = parse_definition(
+            self.stencil,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_int_precision=integer_precision,
+        )
+
+        assert isinstance(def_ir.computations[0].body.stmts[0].condition.rhs, nodes.ScalarLiteral)
+        assert def_ir.computations[0].body.stmts[0].condition.rhs.value == LocalEnum.A
+        assert isinstance(
+            def_ir.computations[0].body.stmts[0].main_body.stmts[0].value, nodes.ScalarLiteral
+        )
+        assert def_ir.computations[0].body.stmts[0].main_body.stmts[0].value.value == LocalEnum.B
+
+    def test_enum_bad_definitions(self):
+
+        @gtscript.enum
+        class MyTestEnum(IntEnum):
+            A = 0
+
+        with pytest.raises(
+            ValueError,
+            match="Enum names must be unique. @gtscript.enum MyTestEnum is already taken*",
+        ):
+
+            @gtscript.enum
+            class MyTestEnum(IntEnum):
+                B = 0
+
+        with pytest.raises(
+            ValueError, match="Enum BadEnumTestEnum needs to derive from `enum.IntEnum`*"
+        ):
+
+            @gtscript.enum  # type: ignore
+            class BadEnumTestEnum(Enum):
+                B = 0.0
+
+        with pytest.raises(
+            ValueError, match="Enum BadStrTestEnum needs to derive from `enum.IntEnum`*"
+        ):
+
+            @gtscript.enum  # type: ignore
+            class BadStrTestEnum(StrEnum):
+                C = "meh"

--- a/tests/next_tests/unit_tests/iterator_tests/ir_utils_tests/test_domain_utils.py
+++ b/tests/next_tests/unit_tests/iterator_tests/ir_utils_tests/test_domain_utils.py
@@ -214,6 +214,26 @@ def test_promote_domain(testee_ranges, dimensions, expected_ranges):
         assert promoted == expected
 
 
+def test_concat_where_branch_domain():
+    """The complement has to be taken before promoting, so the two are pinned together.
+
+    `domain_complement` is only defined on ranges that are infinite on exactly one side, which a
+    promoted dimension is not, so promoting first gives a different (wrong) result.
+    """
+    domain = _make_domain({I: (0, 10), J: (0, 10)})
+    cond = domain_utils.SymbolicDomain(
+        grid_type=common.GridType.CARTESIAN,
+        ranges={J: domain_utils.SymbolicRange(5, itir.InfinityLiteral.POSITIVE)},
+    )
+
+    assert domain_utils.concat_where_branch_domain(domain, cond, True).as_expr() == im.domain(
+        common.GridType.CARTESIAN, {I: (0, 10), J: (5, 10)}
+    )
+    assert domain_utils.concat_where_branch_domain(domain, cond, False).as_expr() == im.domain(
+        common.GridType.CARTESIAN, {I: (0, 10), J: (0, 5)}
+    )
+
+
 def test_is_finite_symbolic_range():
     assert not domain_utils.is_finite(infinity_range)
     assert not domain_utils.is_finite(left_infinity_range)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_concat_where_broadcast_branches.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_concat_where_broadcast_branches.py
@@ -1,0 +1,65 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+import pytest
+
+from gt4py.next import common
+from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator.transforms import concat_where
+from gt4py.next.type_system import type_specifications as ts
+
+Vertex = common.Dimension(value="Vertex", kind=common.DimensionKind.HORIZONTAL)
+K = common.Dimension(value="K", kind=common.DimensionKind.VERTICAL)
+
+float64 = ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+vertex_k_field = ts.FieldType(dims=[Vertex, K], dtype=float64)
+vertex_field = ts.FieldType(dims=[Vertex], dtype=float64)
+k_field = ts.FieldType(dims=[K], dtype=float64)
+
+cond = im.domain(common.GridType.UNSTRUCTURED, {K: (itir.InfinityLiteral.NEGATIVE, 0)})
+
+
+def _broadcast(expr):
+    return im.call("broadcast")(
+        expr,
+        im.make_tuple(
+            *(itir.AxisLiteral(value=dim.value, kind=dim.kind) for dim in (Vertex, K)),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "true_branch_type, false_branch_type",
+    [
+        (vertex_field, vertex_k_field),
+        (vertex_k_field, k_field),
+        (k_field, vertex_field),
+    ],
+)
+def test_broadcast_branches(true_branch_type, false_branch_type):
+    testee = im.concat_where(cond, im.ref("a", true_branch_type), im.ref("b", false_branch_type))
+
+    expected = im.concat_where(
+        cond,
+        im.ref("a") if true_branch_type == vertex_k_field else _broadcast(im.ref("a")),
+        im.ref("b") if false_branch_type == vertex_k_field else _broadcast(im.ref("b")),
+    )
+
+    assert concat_where.broadcast_branches(testee) == expected
+
+
+def test_no_broadcast_when_branches_span_all_dimensions():
+    testee = im.concat_where(cond, im.ref("a", vertex_k_field), im.ref("b", vertex_k_field))
+
+    assert concat_where.broadcast_branches(testee) == testee
+
+
+def test_no_broadcast_without_type_information():
+    testee = im.concat_where(cond, "a", "b")
+
+    assert concat_where.broadcast_branches(testee) == testee

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_prune_empty_concat_where.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_prune_empty_concat_where.py
@@ -11,7 +11,10 @@ from gt4py.next import common
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.transforms.prune_empty_concat_where import prune_empty_concat_where
-from gt4py.next.iterator.transforms.concat_where import canonicalize_domain_argument
+from gt4py.next.iterator.transforms.concat_where import (
+    broadcast_branches,
+    canonicalize_domain_argument,
+)
 from gt4py.next.iterator.transforms.infer_domain import infer_expr
 from gt4py.next.iterator.transforms.inline_lambdas import InlineLambdas
 from gt4py.next.iterator.ir_utils import domain_utils
@@ -75,13 +78,22 @@ def test_prune_concat_where(accessed_domain, cond_domain, expected):
     assert actual == expected
 
 
-def _concat_where(cond_range, true_branch_type, false_branch_type):
+def _broadcast(expr):
+    return im.call("broadcast")(
+        expr,
+        im.make_tuple(*(itir.AxisLiteral(value=dim.value, kind=dim.kind) for dim in (Vertex, K))),
+    )
+
+
+def _concat_where(cond_range, true_branch_type, false_branch_type, *, broadcast=False):
     """A `concat_where` on `K` accessed on the domain `Vertex: [0, 10), K: [0, 10)`."""
     testee = im.concat_where(
         im.domain(common.GridType.UNSTRUCTURED, {K: cond_range}),
         im.ref("a", true_branch_type),
         im.ref("b", false_branch_type),
     )
+    if broadcast:
+        testee = broadcast_branches(testee)
     testee = canonicalize_domain_argument(testee)
     testee, _ = infer_expr(
         testee,
@@ -108,11 +120,39 @@ def test_prune_condition_disjoint_from_accessed_domain(cond_range, expected):
     assert prune_empty_concat_where(testee) == im.ref(expected)
 
 
+@pytest.mark.parametrize(
+    "cond_range",
+    [
+        (itir.InfinityLiteral.NEGATIVE, 0),  # entirely below the accessed domain
+        (10, itir.InfinityLiteral.POSITIVE),  # entirely above it
+    ],
+)
+def test_prune_branch_that_lacks_the_concat_dimension(cond_range):
+    """A branch selected nowhere is pruned even when it does not have the concat dimension.
+
+    The domain of such a branch is restricted to the dimensions of its own type and hence has no
+    range in the concat dimension, so it is only recognized as empty after the implicit broadcast
+    has been made explicit.
+    """
+    testee = _concat_where(cond_range, vertex_field, vertex_k_field, broadcast=True)
+
+    assert prune_empty_concat_where(testee) == im.ref("b")
+
+
+def test_prune_to_branch_that_lacks_a_dimension():
+    """The surviving branch is broadcast to the dimensions of the `concat_where`."""
+    testee = _concat_where(
+        (itir.InfinityLiteral.NEGATIVE, 0), vertex_k_field, k_field, broadcast=True
+    )
+
+    assert prune_empty_concat_where(testee) == _broadcast(im.ref("b"))
+
+
 def test_no_prune_when_the_surviving_branch_lacks_a_dimension():
     """Pruning must not silently drop a dimension.
 
-    The true branch is never selected, but the false branch does not have the `Vertex` dimension,
-    so replacing the `concat_where` by it would turn a two dimensional expression into a one
+    Without the explicit broadcast the false branch does not have the `Vertex` dimension, so
+    replacing the `concat_where` by it would turn a two dimensional expression into a one
     dimensional one.
     """
     testee = _concat_where((itir.InfinityLiteral.NEGATIVE, 0), vertex_k_field, k_field)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_prune_empty_concat_where.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_prune_empty_concat_where.py
@@ -15,9 +15,15 @@ from gt4py.next.iterator.transforms.concat_where import canonicalize_domain_argu
 from gt4py.next.iterator.transforms.infer_domain import infer_expr
 from gt4py.next.iterator.transforms.inline_lambdas import InlineLambdas
 from gt4py.next.iterator.ir_utils import domain_utils
+from gt4py.next.type_system import type_specifications as ts
 
 Vertex = common.Dimension(value="Vertex", kind=common.DimensionKind.HORIZONTAL)
 K = common.Dimension(value="K", kind=common.DimensionKind.VERTICAL)
+
+float64 = ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+vertex_k_field = ts.FieldType(dims=[Vertex, K], dtype=float64)
+vertex_field = ts.FieldType(dims=[Vertex], dtype=float64)
+k_field = ts.FieldType(dims=[K], dtype=float64)
 
 
 @pytest.mark.parametrize(
@@ -67,3 +73,48 @@ def test_prune_concat_where(accessed_domain, cond_domain, expected):
     actual = prune_empty_concat_where(testee)
     actual = InlineLambdas.apply(actual)
     assert actual == expected
+
+
+def _concat_where(cond_range, true_branch_type, false_branch_type):
+    """A `concat_where` on `K` accessed on the domain `Vertex: [0, 10), K: [0, 10)`."""
+    testee = im.concat_where(
+        im.domain(common.GridType.UNSTRUCTURED, {K: cond_range}),
+        im.ref("a", true_branch_type),
+        im.ref("b", false_branch_type),
+    )
+    testee = canonicalize_domain_argument(testee)
+    testee, _ = infer_expr(
+        testee,
+        domain_utils.SymbolicDomain.from_expr(
+            im.domain(common.GridType.UNSTRUCTURED, {Vertex: (0, 10), K: (0, 10)})
+        ),
+        offset_provider={},
+    )
+    return testee
+
+
+@pytest.mark.parametrize(
+    "cond_range, expected",
+    [
+        ((itir.InfinityLiteral.NEGATIVE, 0), "b"),  # entirely below the accessed domain
+        ((10, itir.InfinityLiteral.POSITIVE), "b"),  # entirely above it
+        ((itir.InfinityLiteral.NEGATIVE, 10), "a"),  # covers it from below
+        ((0, itir.InfinityLiteral.POSITIVE), "a"),  # covers it from above
+    ],
+)
+def test_prune_condition_disjoint_from_accessed_domain(cond_range, expected):
+    testee = _concat_where(cond_range, vertex_k_field, vertex_k_field)
+
+    assert prune_empty_concat_where(testee) == im.ref(expected)
+
+
+def test_no_prune_when_the_surviving_branch_lacks_a_dimension():
+    """Pruning must not silently drop a dimension.
+
+    The true branch is never selected, but the false branch does not have the `Vertex` dimension,
+    so replacing the `concat_where` by it would turn a two dimensional expression into a one
+    dimensional one.
+    """
+    testee = _concat_where((itir.InfinityLiteral.NEGATIVE, 0), vertex_k_field, k_field)
+
+    assert prune_empty_concat_where(testee) == testee


### PR DESCRIPTION
> *Written by Claude, not reviewed by @havogt.*

**Staged on the fork for discussion — an alternative to GridTools/gt4py#2767, not a replacement proposal.** It implements the design @tehrengruber suggested in review there: prune from the arguments rather than from the `concat_where`'s own domain, since `concat_where` implicitly broadcasts the dimensions a branch lacks.

## The finding that shaped it

Pruning from the branch domains alone **cannot** fix the never-selected-branch bug: the information is not present. Two expressions with byte-identical branch domains require opposite answers, differing only in `node.annex.domain`:

| | accessed domain | `a.annex.domain` | `b.annex.domain` | correct |
|---|---|---|---|---|
| A | `V:[0,10[, K:[0,10[` | `V:[0,10[` | `V:[0,10[, K:[0,10[` | prune to `b` |
| B | `V:[0,10[, K:[-5,10[` | `V:[0,10[` | `V:[0,10[, K:[0,10[` | must not prune |

`a: Field[[Vertex]]`, `b: Field[[Vertex, K]]`, condition `K < 0` in both. `infer_expr` filters each branch's domain to the dimensions of the branch's own type, and for the branch lacking the concat dimension the one range that would be empty is exactly the one dropped.

So the design completes in one of three ways: feed the promotion the `concat_where`'s domain (that is #2767), materialise the broadcast in the IR, or leave that bug unfixed. This branch does the second, which is what the review comment writes out as `broadcast(a, (Vertex, K))`.

## The two commits

1. **`b04eb80b8`** — decide pruning from the branches' domains. Computes the `concat_where`'s dimension set as `cond ∪ tb ∪ fb` from the branch annex domains, promotes the candidate branch's domain to it, intersects with the (complemented) condition, and prunes only if the kept branch spans all of them. Never reads `node.annex.domain`, never reads `.type`. Shares `domain_utils.concat_where_branch_domain()` with `infer_domain._infer_concat_where`, so the complement-before-promote ordering exists in one place.
2. **`23b02ad50`** — a `concat_where.broadcast_branches` pass making the implicit broadcast explicit, wired into both pass managers after `infer_domain_ops` and before `canonicalize_domain_argument`. After it every branch spans the full dimensions, so the branch-domain test is sufficient. It runs `type_inference.reinfer` itself, which is legitimate at that point because it is before `_infer_concat_where` drops the type.

The split is deliberate: commit 2 can be dropped, in which case the never-selected-branch bug stays open.

## Both fixes are needed, they are not alternatives

The dimension-dropping bug is a **hard compile failure**, not a pessimisation — `inference.visit_SetAt`'s `assert expr_type.dims == target_type.dims` fires, reproduced from plain user code on gtfn. Under `python -O` the assert disappears and the mismatch reaches the backend. It requires statically known bounds, which is why the existing ffront tests miss it (`cases` produces runtime bounds, so nothing prunes) and is exactly icon4py's compilation mode.

The never-selected-branch bug is only a missed optimisation; the numbers are correct either way.

## Cost, which is the least certain part

`broadcast_branches` runs type inference and rewrites IR for every `concat_where` with a lower-dimensional branch — a common icon4py shape. Measured: gtfn output byte-identical for a non-prunable case (`fuse_as_fieldop` absorbs the `deref`), the DaCe path produces exactly the `as_fieldop(deref, D ∩ cond)` its own lowering was constructing internally, and no test churn. But that is not evidence at scale, and it touches code currently being performance tuned.

## Testing

`iterator_tests` 503 → 517. Every regression test verified to fail with its fix removed, keeping the module importable in each case. The ordering test asserts a *value* rather than pinning an `AssertionError`, so it also fails under `python -O`. Full `integration_tests` on roundtrip + numpy + gtfn: 2030 passed. `ruff`, `tach`, `mypy` clean.

## Follow-up worth noting

With `broadcast_branches` in the pipeline, the promotion path in `_translate_concat_where_branch()` (`gtir_to_sdfg_concat_where.py`) becomes unreachable, since `len(source_expr.type.dims) < len(output_type.dims)` can no longer hold. Left alone here — out of scope, and `translate_concat_where` could still be handed unnormalised IR.