### PR TITLE
fix[next]: lower `as_offset` applied to a staggered access

### DIFF
--- a/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
+++ b/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
@@ -64,19 +64,26 @@ class InlineDynamicShifts(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
                     node, eligible_params=list(inline_let_params.values())
                 )
 
-        if dynamic_shift_args := _dynamic_shift_args(node):
-            assert len(node.fun.args) in [1, 2]  # type: ignore[attr-defined]  # ensured by is_applied_as_fieldop in _dynamic_shift_args
+        # Fusing one producer can expose another one behind it (e.g. a chain of shifts split
+        # across multiple `as_fieldop`s), so repeat until no dynamically shifted argument is left.
+        expr: itir.Expr = node
+        while dynamic_shift_args := _dynamic_shift_args(expr):
+            assert isinstance(expr, itir.FunCall) and len(expr.fun.args) in [1, 2]  # type: ignore[attr-defined]  # ensured by is_applied_as_fieldop in _dynamic_shift_args
             fuse_args = [
                 not isinstance(inp, itir.SymRef) and dynamic_shift_arg
-                for inp, dynamic_shift_arg in zip(node.args, dynamic_shift_args, strict=True)
+                for inp, dynamic_shift_arg in zip(expr.args, dynamic_shift_args, strict=True)
             ]
-            if any(fuse_args):
-                return fuse_as_fieldop.fuse_as_fieldop(
-                    node,
-                    fuse_args,
-                    uids=self.uids,
-                    offset_provider_type=self.offset_provider_type,
-                    enable_cse=True,
-                )
+            if not any(fuse_args):
+                break
+            fused = fuse_as_fieldop.fuse_as_fieldop(
+                expr,
+                fuse_args,
+                uids=self.uids,
+                offset_provider_type=self.offset_provider_type,
+                enable_cse=True,
+            )
+            if fused == expr:
+                break
+            expr = fused
 
-        return node
+        return expr

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
@@ -1525,7 +1525,7 @@ class LambdaToDataflow(eve.NodeVisitor):
                     name="dynamic_offset",
                     inputs={"index"},
                     outputs={new_index_connector},
-                    code=f"{new_index_connector} = index + {offset_expr}",
+                    code=f"{new_index_connector} = index + {offset_expr.value}",
                 )
             else:
                 dynamic_offset_tasklet, connector_mapping = self._add_tasklet(

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_primitives.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_primitives.py
@@ -236,7 +236,8 @@ def translate_as_fieldop(
     assert isinstance(node.type, (ts.FieldType, ts.TupleType))
 
     fun_node = node.fun
-    assert len(fun_node.args) == 2
+    if len(fun_node.args) != 2:
+        raise ValueError(f"Missing domain on 'as_fieldop' node: '{node}'.")
     fieldop_expr, fieldop_domain_expr = fun_node.args
 
     if cpm.is_call_to(fieldop_expr, "scan"):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
@@ -9,17 +9,23 @@ import numpy as np
 import pytest
 
 import gt4py.next as gtx
+from gt4py.next.ffront.experimental import as_offset
 
 from next_tests.integration_tests import cases
 from next_tests.integration_tests.cases import (
+    E2V,
+    Edge,
     IDim,
     IHalfDim,
     JDim,
     KDim,
     KHalfDim,
+    Vertex,
     cartesian_case,
+    unstructured_case,
+    unstructured_case_3d,
 )
-from next_tests.integration_tests.cases_utils import exec_alloc_descriptor
+from next_tests.integration_tests.cases_utils import exec_alloc_descriptor, mesh_descriptor
 
 
 @pytest.mark.uses_cartesian_shift
@@ -140,3 +146,67 @@ def test_cartesian_half_shift_multi_dim(cartesian_case):
     )()
 
     cases.verify(cartesian_case, testee, a, out=out, ref=a, offset_provider={})
+
+
+@pytest.mark.uses_cartesian_shift
+@pytest.mark.uses_dynamic_offsets
+def test_cartesian_half_shift_as_offset(cartesian_case):
+    Koff = gtx.FieldOffset("Koff", source=KDim, target=(KDim,))
+
+    @gtx.field_operator
+    def testee(
+        a: gtx.Field[[IDim, KHalfDim], np.int32], offset_field: cases.IKField
+    ) -> cases.IKField:
+        return a(KDim - 0.5)(as_offset(Koff, offset_field))
+
+    isize = cartesian_case.default_sizes[IDim]
+    ksize = cartesian_case.default_sizes[KDim]
+    a = cases.allocate(cartesian_case, testee, "a", sizes={IDim: isize, KHalfDim: ksize + 1})()
+    offset_field = cases.allocate(
+        cartesian_case,
+        testee,
+        "offset_field",
+        sizes={IDim: isize, KDim: ksize},
+        strategy=cases.ConstInitializer(1),
+    )()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN, sizes={IDim: isize, KDim: ksize})()
+
+    cases.verify(
+        cartesian_case, testee, a, offset_field, out=out, ref=a.asnumpy()[:, 1:], offset_provider={}
+    )
+
+
+@pytest.mark.uses_unstructured_shift
+@pytest.mark.uses_dynamic_offsets
+def test_unstructured_shift_half_shift_as_offset(unstructured_case_3d):
+    Koff = gtx.FieldOffset("Koff", source=KDim, target=(KDim,))
+
+    @gtx.field_operator
+    def testee(
+        a: gtx.Field[[Vertex, KHalfDim], np.int32],
+        offset_field: gtx.Field[[Edge, KDim], np.int32],
+    ) -> gtx.Field[[Edge, KDim], np.int32]:
+        return a(E2V[0])(KDim - 0.5)(as_offset(Koff, offset_field))
+
+    nvertices = unstructured_case_3d.default_sizes[Vertex]
+    ksize = unstructured_case_3d.default_sizes[KDim]
+    a = cases.allocate(
+        unstructured_case_3d,
+        testee,
+        "a",
+        domain={Vertex: (0, nvertices), KHalfDim: (0, ksize + 1)},
+    )()
+    offset_field = cases.allocate(
+        unstructured_case_3d, testee, "offset_field", strategy=cases.ConstInitializer(1)
+    )()
+    out = cases.allocate(unstructured_case_3d, testee, cases.RETURN)()
+
+    e2v_table = unstructured_case_3d.offset_provider["E2V"].asnumpy()
+    cases.verify(
+        unstructured_case_3d,
+        testee,
+        a,
+        offset_field,
+        out=out,
+        ref=a.asnumpy()[e2v_table[:, 0], 1:],
+    )

--- a/tests/next_tests/unit_tests/iterator_tests/test_inline_dynamic_shifts.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_inline_dynamic_shifts.py
@@ -30,6 +30,25 @@ def test_inline_dynamic_shift_as_fieldop_arg(uids):
     assert actual == expected
 
 
+def test_inline_dynamic_shift_nested_as_fieldop_args(uids):
+    testee = im.as_fieldop(im.lambda_("a", "b")(im.deref(im.shift(IOff, im.deref("b"))("a"))))(
+        im.as_fieldop(im.lambda_("a")(im.deref(im.shift(IOff, 1)("a"))))(
+            im.as_fieldop("deref")("inp")
+        ),
+        "offset_field",
+    )
+    expected = im.as_fieldop(
+        im.lambda_("inp", "offset_field")(
+            im.deref(im.shift(IOff, 1)(im.shift(IOff, im.deref("offset_field"))("inp")))
+        )
+    )("inp", "offset_field")
+
+    actual = inline_dynamic_shifts.InlineDynamicShifts.apply(
+        testee, offset_provider_type={}, uids=uids
+    )
+    assert actual == expected
+
+
 def test_inline_dynamic_shift_let_var(uids):
     testee = im.let("tmp", im.as_fieldop("deref")("inp"))(
         im.as_fieldop(im.lambda_("a", "b")(im.deref(im.shift(IOff, im.deref("b"))("a"))))(


### PR DESCRIPTION
A staggered access underneath `as_offset` fails on the dace backend. Reduced from icon4py's `compute_hydrostatic_correction_term` (mo_solve_nonhydro_stencil_21) once `theta_v_ic` lives on a staggered dimension:

```python
theta_v_ic(E2C[0])(dims.KDim - 0.5)(as_offset(Koff, ikoffset[dims.E2CDim(0)]))
```

The composition order is forced — `as_offset` requires the offset field to carry the dimension being shifted, so the half-integer shift has to come first. This blocks the *default* ICON backend (`icon4py_backend = 0` resolves to `make_custom_dace_backend`), stopping a blueline run at the first dycore predictor step.

Four cases, all writing to a full-level (`K`) output, on `main`:

| | expression | gtfn_cpu | dace_cpu |
|---|---|---|---|
| A | `cell(as_offset(Koff, off))` | ok | ok |
| B | `cell(K - 0.5)(as_offset(Koff, off))` | ok | **`KeyError: 'int'`** |
| C | `cell(E2C[0])(as_offset(Koff, off))` | ok | ok |
| D | `cell(E2C[0])(K - 0.5)(as_offset(Koff, off))` | ok | **`AssertionError`** |

The trigger is the staggered access underneath `as_offset` — not `as_offset` itself (A passes) and not the unstructured shift (C passes). B and D turn out to be two independent defects sharing that one trigger.

### Not an intentional limitation

Checked first, since a deliberate exclusion would call for a clear error rather than a lowering fix. It is not one: `test_staggered.py` passes 18/18 on `dace_cpu` on unmodified `main`, `tests/next_tests/definitions.py` carries no skip/xfail excluding staggered dims from dace, and ADR `next/0026` documents only gtfn's tag-aliasing approach — it says nothing about dace being out of scope. The absent coverage was incidental.

### B — `SymbolExpr` leaking into generated tasklet code

`_make_cartesian_shift` interpolated the whole dataclass rather than its value when a static cartesian shift landed on an already dynamically shifted iterator, emitting

```
shifted_index = index + SymbolExpr(value=0, dc_dtype=int)
```

dace parses that, picks up `int` as a free symbol, and fails in `sdfg.arglist()` with `KeyError: 'int'`. The branch is reachable without staggering (`shift(Koff, 1)` over an `as_offset`), but a half-integer shift *always* lowers to a static cartesian shift, so staggering turns a corner case into the normal path.

### D — `InlineDynamicShifts` did not fuse to a fixpoint

The pass fused one producer per node and returned. Case D nests three `as_fieldop`s (dynamic offset → staggered shift → `E2C`); after a single fusion the `E2C` producer is *still* behind a dynamic shift, so domain inference marks it `UNKNOWN` and emits it without a domain:

```
as_fieldop(λ(__iasfop_0, off) → ·⟪Kᵥ→_StaggeredKᵥ, 0ₒ⟫(⟪Kᵥ→Kᵥ, ·off⟫(__iasfop_0)),
           u⟨ Edgeₕ: [0, n[, Kᵥ: [0, nlev[ ⟩)((⇑(λ(__it) → ·⟪E2Cₒ, 0ₒ⟫(__it)))(cell), off)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no domain
```

This is **not dace-specific**: `roundtrip.gtir` fails the new test on `main` too. Both use `apply_fieldview_transforms`, which ends at `infer_domain`. `apply_common_transforms` was masking the defect via its later `fuse_as_fieldop` loop, which is why gtfn handles all four cases. Fixed by fusing until no dynamically shifted argument is left.

### `assert` → explicit error

`translate_as_fieldop` guarded the domain with a bare `assert len(fun_node.args) == 2`. ICON's generated `setting` script exports `PYTHONOPTIMIZE`, which strips the assert, so control fell through to the tuple unpack on the next line and the same defect reported as `ValueError: not enough values to unpack (expected 2, got 1)`. Now an explicit `ValueError` naming the missing domain.

### Tests

- `test_inline_dynamic_shift_nested_as_fieldop_args` — backend-free spec for the fusion fixpoint.
- `test_cartesian_half_shift_as_offset` — case B, value-verified.
- `test_unstructured_shift_half_shift_as_offset` — case D, the icon4py shape, value-verified.

Each fails on `main` and passes here. Full `next` suite: 6305 passed, 0 failed. `pre-commit` (ruff, mypy, tach) clean.

**GPU is unverified.** `cupy` cannot initialise in my environment (`cudaErrorUnknown` at `getDeviceCount`, driver 595.71.05 / CUDA 13.2), and all 27 pre-existing GPU staggered tests fail there on unmodified `main` for the same reason. The changed code paths are not device-specific, but the GPU matrix needs a run on working hardware before merge.
